### PR TITLE
Set gcc rpath option on linux

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -159,6 +159,8 @@ def create_base_env(vars):
     if "gcc" in env["TOOLS"]:
         env.MergeFlags("-pthread")
         env.AppendUnique(CXXFLAGS=["-std=c++03"])
+        env.Append( LINKFLAGS = Split('-z origin') )
+        env.Append( RPATH = env.Literal("$prefix/lib") )
     if sys.platform.startswith("linux"):
         env.Append(SHLINKFLAGS="-Wl,-soname,${TARGET.file}.${libversion.split('.')[0]}")
     return env


### PR DESCRIPTION
Set gcc rpath option to $prefix/lib. This fixes  usecase where RHVoice is installed into a custom prefix and fails with error 
"error while loading shared libraries: libRHVoice_audio.so.0: cannot open shared object file: No such file or directory"
when you try to run it