### PR TITLE
Implemented CMake building for Linux components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 local/
 *.pyc
+/src/include/core/config.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,120 @@
+# Copyright (C) 2010, 2011, 2012, 2013, 2014, 2018  Olga Yakovleva <yakovleva.o.v@gmail.com>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+cmake_minimum_required(VERSION 3.5.1)
+project("RHVoice")
+
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_SOURCE_DIR}/cmake")
+include(FindPkgConfig)
+include(GNUInstallDirs)
+include(CPackComponent)
+include(Hardening)
+include(VersionFromGit)
+getVersionFromGit("RHVOICE" "1.2.2")
+
+if(${CMAKE_VERSION} VERSION_GREATER "3.12") 
+	set(CMAKE_CXX_STANDARD 20)
+else()
+	if(${CMAKE_VERSION} VERSION_GREATER "3.8") 
+		set(CMAKE_CXX_STANDARD 17)
+	else()
+		set(CMAKE_CXX_STANDARD 14)
+	endif()
+endif()
+
+
+set(CMAKE_C_STANDARD 11)
+
+
+macro(pass_through_cpack_vars)
+	get_cmake_property(cpackVarsToPassthrough VARIABLES)
+	foreach(varName ${cpackVarsToPassthrough})
+		if(varName MATCHES "^CPACK_")
+			set("${varName}" "${${varName}}" PARENT_SCOPE)
+		endif()
+	endforeach()
+endmacro()
+
+#def create_languages_user_var():
+#    names=sorted(os.listdir(Dir("#data").Dir("languages").abspath))
+#    langs=[name.lower() for name in names]
+#    name_map=dict(zip(names,langs))
+#    def_langs=langs
+#    if sys.platform!="win32":
+#        def_langs=[lang for lang in langs if lang not in["georgian"]]
+#    help="Which languages to install"
+#    return ListVariable("languages",help,def_langs,langs,name_map)
+
+if(CMAKE_INSTALL_PREFIX EQUAL "/usr")
+	set(CMAKE_INSTALL_SYSCONFDIR "/etc")
+endif()
+
+
+set("dev" OFF CACHE BOOL "The build will only be used for development: no global installation, run from the source directory, compile helper utilities")
+set("ENABLE_MAGE" ON CACHE BOOL "Build with MAGE")
+set("WITH_DATA" ON CACHE BOOL "Build packages with data. Long to compress. When debugging RHVoice itself it makes sense to disable it.")
+#set("spd_version" validate_spd_version CACHE ??? "Speech dispatcher version")
+set("release" ON CACHE BOOL "Whether we are building a release")
+set("enable_xp_compat" ON CACHE BOOL "Target Windows XP")
+set("msi_repo" "" CACHE PATH "Where the msi packages are kept for reuse")
+set("servicedir" "${CMAKE_INSTALL_FULL_DATADIR}/dbus-1/services" CACHE PATH ".service file installation directory")
+
+set("data_dir" "${CMAKE_INSTALL_FULL_DATADIR}/RHVoice")
+set("languages_dir" "${data_dir}/languages")
+set("voices_dir" "${data_dir}/voices")
+
+set("config_dir" "${CMAKE_INSTALL_FULL_SYSCONFDIR}/RHVoice")
+set("common_doc_dir" "${CMAKE_INSTALL_FULL_DATAROOTDIR}/doc")
+
+set(SubpackagesDir "${CMAKE_CURRENT_SOURCE_DIR}/src")
+set("licenses_dir" "${CMAKE_CURRENT_SOURCE_DIR}/licenses")
+set("voice_licenses_dir" "${licenses_dir}/voices")
+
+add_subdirectory("${SubpackagesDir}")
+add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/config")
+if(WITH_DATA)
+	add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/data")
+endif()
+
+set(CPACK_PACKAGE_CHECKSUM "SHA512")
+set(CPACK_GENERATOR "DEB")
+set(CPACK_DEBIAN_COMPRESSION_TYPE "xz")
+option(CPACK_RPM_COMPONENT_INSTALL "Split into multiple rpm packages" ON)
+option(CPACK_DEB_COMPONENT_INSTALL "Split into multiple deb packages" ON)
+set(CPACK_PACKAGE_VENDOR "Olga Yakovleva")
+set(CPACK_PACKAGE_CONTACT "https://github.com/Olga-Yakovleva/RHVoice")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/Olga-Yakovleva/RHVoice")
+
+if(ENABLE_MAGE)
+	set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/licenses/gpl-3.0.txt")
+else()
+	set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/licenses/lgpl-2.1.txt")
+endif()
+
+set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
+
+set(CPACK_DEBIAN_PACKAGE_NAME "RHVoice")
+set(CPACK_PACKAGE_VERSION_MAJOR "${RHVOICE_VERSION_MAJOR}")
+set(CPACK_PACKAGE_VERSION_MINOR "${RHVOICE_VERSION_MINOR}")
+set(CPACK_PACKAGE_VERSION_PATCH "${RHVOICE_VERSION_PATCH}")
+set(CPACK_PACKAGE_VERSION_TWEAK "${RHVOICE_VERSION_TWEAK}")
+
+set(CPACK_COMPONENTS_GROUPING "IGNORE")
+
+set(CPACK_MONOLITHIC_INSTALL OFF)
+set(CPACK_PACKAGE_DESCRIPTION_FILE "${CPACK_RESOURCE_FILE_README}")
+
+include(CPack)

--- a/cmake/CheckSpdVersion.cmake
+++ b/cmake/CheckSpdVersion.cmake
@@ -1,0 +1,14 @@
+def CheckSpdVersion(ctx):
+    ctx.Message("Checking Speech Dispatcher version ... ")
+    ver=ctx.env.get("spd_version",None)
+    if ver is not None:
+        ctx.Result(ver)
+        return ver
+    src='#include <stdio.h>\n#include <speech-dispatcher/libspeechd_version.h>\nint main() {\nint major=LIBSPEECHD_MAJOR_VERSION;\nint minor=LIBSPEECHD_MINOR_VERSION;\nprintf("%d.%d",major,minor);\nreturn 0;}'
+    res,ver=ctx.TryRun(src,".c")
+    if not res:
+        ctx.Result(res)
+        return res
+    ctx.env["spd_version"]=ver
+    ctx.Result(ver)
+    return ver

--- a/cmake/Hardening.cmake
+++ b/cmake/Hardening.cmake
@@ -1,0 +1,205 @@
+#This is free and unencumbered software released into the public domain.
+#Anyone is free to copy, modify, publish, use, compile, sell, or distribute this software, either in source code form or as a compiled binary, for any purpose, commercial or non-commercial, and by any means.
+#In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain. We make this dedication for the benefit of the public at large and to the detriment of our heirs and successors. We intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#For more information, please refer to <https://unlicense.org/>
+
+include(CheckCXXCompilerFlag)
+
+option(HARDENING_SSE2 "Enable hardening flags requiring at least SSE2 support for target" OFF)
+
+function(determineSupportedHardeningFlags property)
+	set(FLAGS_HARDENING "")
+	foreach(flag ${ARGN})
+		unset(var_name)
+		string(REPLACE "=" "_eq_" var_name ${flag})
+		string(REPLACE "," "_comma_" var_name ${var_name})
+		set(var_name "SUPPORTS_HARDENING_${property}_${var_name}")
+		check_cxx_compiler_flag(${flag} ${var_name})#since linker flags and other flags are in the form of compiler flags
+		if(${${var_name}})
+			list(APPEND FLAGS_HARDENING "${flag}")
+		endif()
+	endforeach(flag)
+	string(REPLACE ";" " " FLAGS_HARDENING "${FLAGS_HARDENING}")
+	#message(STATUS "FLAGS_HARDENING ${FLAGS_HARDENING}")
+	set(HARDENING_${property} "${FLAGS_HARDENING}" CACHE STRING "Hardening flags")
+endfunction(determineSupportedHardeningFlags)
+
+function(processFlagsList target property)
+	get_target_property(FLAGS_UNHARDENED ${target} ${property})
+	if(FLAGS_UNHARDENED MATCHES "FLAGS_UNHARDENED-NOTFOUND")
+		set(FLAGS_UNHARDENED "")
+	endif()
+	#message(STATUS "processFlagsList ${target} ${property} ${FLAGS_UNHARDENED}")
+	#message(STATUS "HARDENING_${property} ${HARDENING_${property}}")
+	if(HARDENING_${property})
+	else()
+		determineSupportedHardeningFlags(${property} ${ARGN})
+	endif()
+	
+	set(FLAGS_HARDENED ${FLAGS_UNHARDENED})
+	list(APPEND FLAGS_HARDENED ${HARDENING_${property}})
+	string(REPLACE ";" " " FLAGS_HARDENED "${FLAGS_HARDENED}")
+	#message(STATUS "${target} PROPERTIES ${property} ${FLAGS_HARDENED}")
+	set_target_properties(${target} PROPERTIES ${property} "${FLAGS_HARDENED}")
+endfunction(processFlagsList)
+
+function(setupPIC target)
+	set_property(TARGET ${target} PROPERTY POSITION_INDEPENDENT_CODE ON) # FUCK, doesn't work
+	if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+		get_target_property(type ${target} TYPE)
+		if(type STREQUAL "EXECUTABLE")
+			list(APPEND HARDENING_COMPILER_FLAGS
+				"-fPIE"
+			)
+		else()
+			list(APPEND HARDENING_COMPILER_FLAGS
+				"-fPIC"
+			)
+		endif()
+		list(APPEND HARDENING_LINKER_FLAGS
+			"-pie"
+		)
+	elseif(MSVC)
+		list(APPEND HARDENING_COMPILER_FLAGS
+			"/dynamicbase" "/HIGHENTROPYVA"
+		)
+	else()
+		message(ERROR "The compiler is not supported")
+	endif()
+endfunction(setupPIC)
+
+function(harden target)
+	setupPIC("${target}")
+	if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+		list(APPEND HARDENING_COMPILER_FLAGS
+			"-Wall" "-Wextra" "-Wconversion" "-Wformat" "-Wformat-security" "-Werror=format-security"
+			"-fno-strict-aliasing" "-fno-common"
+			#"-fstack-check"
+			#"-fcf-protection=full" # conflicts to "-mindirect-branch"
+			"-fcf-runtime-abi=full"
+
+			"-ffp-exception-behavior=strict"
+			"-fstack-clash-protection"
+			"-mcet"
+			"-fsanitize=cfi"
+			"-fsanitize=cfi-cast-strict"
+			"-fsanitize=cfi-derived-cast"
+			"-fsanitize=cfi-unrelated-cast"
+			"-fsanitize=cfi-nvcall"
+			"-fsanitize=cfi-vcall"
+			"-fsanitize=cfi-icall"
+			"-fsanitize=cfi-mfcall"
+			
+			# CLang-ish flags
+			"-mretpoline"
+			"-mspeculative-load-hardening"
+			"-lvi-load-hardening"
+			"-lvi-cfi"
+			
+			#"-fsanitize=safe-stack;compiler-rt" # https://clang.llvm.org/docs/SafeStack.html
+			"-fsanitize=address" # https://clang.llvm.org/docs/AddressSanitizer.html
+			
+			# TODO implement compiler flag dependence on libs linking
+			#"-fsanitize=undefined;ubsan" # https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html , gcc also has it
+			
+			#"-fsanitize=thread" # https://clang.llvm.org/docs/ThreadSanitizer.html , 15x slowdown and 10x memory overhead
+			#"-fsanitize=memory" # https://clang.llvm.org/docs/MemorySanitizer.html 3x slowdown
+			#"-fsanitize=dataflow" # https://clang.llvm.org/docs/DataFlowSanitizer.html, taint analysis, requires explicit annotation of code
+			
+			#"-fvtable-verify=std;vtv"
+			
+			# this conflicts with gcc which now has -fcf-protection=full hardcoded
+			"-fcf-protection=none -mindirect-branch"
+			"-fcf-protection=none -mindirect-branch=thunk-extern"
+			"-fcf-protection=none -mindirect-branch=thunk-inline"
+			"-fcf-protection=none -mindirect-return"
+			"-fcf-protection=none -mindirect-branch-register"
+			"-fcf-protection=none -mindirect-branch-loop"
+			
+			"-x86-speculative-load-hardening"
+			"-mno-indirect-branch-register"
+		)
+
+		if(HARDENING_SSE2)
+			list(APPEND HARDENING_COMPILER_FLAGS
+				"-mlfence-after-load=yes"
+				"-mlfence-before-indirect-branch=all"
+				"-mlfence-before-ret=not"
+			)
+		endif(HARDENING_SSE2)
+
+		# some flags are bugged in GCC
+		if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+		else()
+			list(APPEND HARDENING_COMPILER_FLAGS
+				"-ftrapv" # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=35412
+			)
+		endif()
+		
+		# GCC 9 has removed these flags
+		if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 9 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10))
+			message(STATUS "GCC 9 removes some hardening flags but doesn't fail if they are present, instead shows deprecation message. In order to not to put garbage into warnings we don't insert them. See the code of Harden.cmake for the details.")
+		else()
+			list(APPEND HARDENING_COMPILER_FLAGS
+				"-mmitigate-rop" 
+				"-fcheck-pointer-bounds"
+				"-fchkp-treat-zero-size-reloc-as-infinite"
+				"-fchkp-first-field-has-own-bounds"
+				"-fchkp-narrow-bounds"
+				"-fchkp-narrow-to-innermost-array"
+				"-fchkp-optimize"
+				"-fchkp-use-fast-string-functions"
+				"-fchkp-use-nochk-string-functions"
+				"-fchkp-use-static-const-bounds"
+			)
+		endif()
+		
+		list(APPEND HARDENING_LINKER_FLAGS
+			"-Wl,-O1"
+			"-Wl,--sort-common"
+			"-Wl,--as-needed"
+			"-Wl,-flto"
+		)
+		if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+			list(APPEND HARDENING_LINKER_FLAGS
+				"-Wl,--export-all-symbols"
+				"-Wl,--nxcompat"
+				"-Wl,--dynamicbase"
+			)
+			if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+			#	list(APPEND HARDENING_LINKER_FLAGS "-Wl,--image-base,0x140000000") # doesn't work for this project
+			endif()
+		elseif(CMAKE_SYSTEM_NAME MATCHES "Linux") # other using ELF too?
+			list(APPEND HARDENING_COMPILER_FLAGS
+				# on MinGW hello world works, but more complex things just exit without any output or crash in the middle of execution
+				"-fstack-protector"
+				"-fstack-protector-strong"
+			)
+			list(APPEND HARDENING_LINKER_FLAGS
+				# not present in MinGW
+				"-Wl,-z,relro"
+				"-Wl,-z,now"
+				"-Wl,-z,ibtplt"
+				"-Wl,-z,ibt"
+				"-Wl,-z,shstk"
+			)
+		endif()
+		list(APPEND HARDENING_MACRODEFS
+			"-D_FORTIFY_SOURCE=2"
+			"-D_GLIBCXX_ASSERTIONS"
+		)
+	elseif(MSVC)
+		set(HARDENING_COMPILER_FLAGS "/sdl" "/GS" "/SafeSEH" "/guard:cf" "/HIGHENTROPYVA")
+		set(HARDENING_LINKER_FLAGS "/guard:cf")
+	else()
+		message(ERROR "The compiler is not supported")
+	endif()
+
+	processFlagsList(${target} COMPILE_FLAGS ${HARDENING_COMPILER_FLAGS})
+	processFlagsList(${target} LINK_FLAGS ${HARDENING_LINKER_FLAGS})
+	
+	#list(JOIN HARDENING_MACRODEFS " " HARDENING_MACRODEFS) # unneeded, list is needed, not string
+	set(HARDENING_MACRODEFS "${HARDENING_MACRODEFS}" CACHE STRING "Hardening flags CMake list (not string!)")
+	target_compile_definitions(${target} PRIVATE ${HARDENING_MACRODEFS})
+endfunction(harden)

--- a/cmake/VersionFromGit.cmake
+++ b/cmake/VersionFromGit.cmake
@@ -1,0 +1,111 @@
+# #This is free and unencumbered software released into the public domain.
+#Anyone is free to copy, modify, publish, use, compile, sell, or distribute this software, either in source code form or as a compiled binary, for any purpose, commercial or non-commercial, and by any means.
+#In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain. We make this dedication for the benefit of the public at large and to the detriment of our heirs and successors. We intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#For more information, please refer to <https://unlicense.org/>
+
+FIND_PACKAGE(Git)
+function(getVersionFromGit variablesPrefix defaultVersion)
+	if(${variablesPrefix}_VERSION_FROM_GIT)
+		set(VERSION_FROM_GIT "${${variablesPrefix}_VERSION_FROM_GIT}")
+		set(VERSION_TIME "${${variablesPrefix}_VERSION_TIME}")
+		set(VERSION_EXPORT "${${variablesPrefix}_VERSION_EXPORT}")
+		message(STATUS "Using cached versions: ${VERSION_FROM_GIT}, ${VERSION_TIME}, ${VERSION_EXPORT}")
+	else()
+		if(GIT_FOUND)
+			execute_process(
+				COMMAND ${GIT_EXECUTABLE} describe --dirty --long --tags
+				WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+				OUTPUT_VARIABLE VERSION_FROM_GIT
+				RESULT_VARIABLE GIT_RESULT
+				ERROR_QUIET
+				OUTPUT_STRIP_TRAILING_WHITESPACE
+			)
+			if(NOT GIT_RESULT EQUAL 0)
+				message(WARNING "git returned error ${VERSION_FROM_GIT}")
+				set(VERSION_FROM_GIT "unknown")
+			endif()
+
+			execute_process(
+				COMMAND ${GIT_EXECUTABLE} log -1 --pretty=format:%ct
+				WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+				OUTPUT_VARIABLE VERSION_TIME
+				RESULT_VARIABLE GIT_RESULT
+				ERROR_QUIET
+				OUTPUT_STRIP_TRAILING_WHITESPACE
+			)
+			if(NOT GIT_RESULT EQUAL 0)
+				set(VERSION_TIME "0000000000" PARENT_SCOPE)
+			endif()
+
+			execute_process(
+				COMMAND ${GIT_EXECUTABLE} log -1 --pretty=format:%D
+				WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+				OUTPUT_VARIABLE VERSION_EXPORT
+				RESULT_VARIABLE GIT_RESULT
+				ERROR_QUIET
+				OUTPUT_STRIP_TRAILING_WHITESPACE
+			)
+			if(NOT GIT_RESULT EQUAL 0)
+				set(VERSION_EXPORT "HEAD -> master")
+			endif()
+		else(GIT_FOUND)
+			set(VERSION_FROM_GIT ${defaultVersion} PARENT_SCOPE)
+		endif(GIT_FOUND)
+		set(${variablesPrefix}_VERSION_FROM_GIT "${VERSION_FROM_GIT}" CACHE STRING "Version from git")
+		set(${variablesPrefix}_VERSION_TIME "${VERSION_TIME}" CACHE STRING "Commit time from git")
+		set(${variablesPrefix}_VERSION_EXPORT "${VERSION_EXPORT}" CACHE STRING "Commit time from git")
+	endif()
+
+	if(VERSION_EXPORT)
+	else()
+		set(VERSION_EXPORT "HEAD -> master")
+	endif()
+	if(VERSION_TIME)
+	else()
+		set(VERSION_TIME "0000000000")
+	endif()
+
+	string(REGEX MATCH "^v?[0-9]+(\\.[0-9]+)+" VERSION ${VERSION_FROM_GIT})
+	set(${variablesPrefix}_VERSION "${VERSION}" PARENT_SCOPE)
+	message(STATUS "${variablesPrefix} version: ${VERSION}")
+
+	string(REGEX MATCHALL "[0-9]+" PARSED_VER ${VERSION})
+
+	list(LENGTH PARSED_VER PARSED_VER_LEN)
+	if(PARSED_VER_LEN GREATER 0)
+		list(GET PARSED_VER 0 VERSION_MAJOR)
+	else()
+		set(VERSION_MAJOR 0)
+	endif()
+	set(${variablesPrefix}_VERSION_MAJOR "${VERSION_MAJOR}" PARENT_SCOPE)
+
+	if(PARSED_VER_LEN GREATER 1)
+		list(GET PARSED_VER 1 VERSION_MINOR)
+	else()
+		set(VERSION_MINOR 0)
+	endif()
+	set(${variablesPrefix}_VERSION_MINOR "${VERSION_MINOR}" PARENT_SCOPE)
+
+	if(PARSED_VER_LEN GREATER 2)
+		list(GET PARSED_VER 2 VERSION_PATCH)
+	else()
+		set(VERSION_PATCH 0)
+	endif()
+	set(${variablesPrefix}_VERSION_PATCH "${VERSION_PATCH}" PARENT_SCOPE)
+
+	if(PARSED_VER_LEN GREATER 3)
+		list(GET PARSED_VER 3 VERSION_TWEAK)
+	else()
+		set(VERSION_TWEAK 0)
+	endif()
+	set(${variablesPrefix}_VERSION_TWEAK "${VERSION_TWEAK}" PARENT_SCOPE)
+
+	set(VERSION_BIN "${VERSION_MAJOR}${VERSION_MINOR}${VERSION_PATCH}")
+	set(${variablesPrefix}_VERSION_BIN "${VERSION_BIN}" PARENT_SCOPE)
+	message(STATUS "${variablesPrefix} bin version: ${VERSION_BIN}")
+
+	set(VERSION_FULL "${VERSION_EXPORT} ${${variablesPrefix}_VERSION_FROM_GIT}")
+	set(${variablesPrefix}_VERSION_FULL "${VERSION_FULL}" PARENT_SCOPE)
+	message(STATUS "version full: ${VERSION_FULL}")
+endfunction()

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright (C) 2010, 2011, 2012, 2013, 2014, 2018  Olga Yakovleva <yakovleva.o.v@gmail.com>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/RHVoice.conf"
+	DESTINATION "${config_dir}"
+	COMPONENT "core"
+)

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,0 +1,61 @@
+# Copyright (C) 2010, 2011, 2012, 2013, 2014, 2018  Olga Yakovleva <yakovleva.o.v@gmail.com>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+cpack_add_component_group("data")
+
+
+set("ISO639_1_NAME2CODE_Russian" "ru")
+set("ISO639_1_NAME2CODE_English" "en")
+set("ISO639_1_NAME2CODE_Ukrainian" "uk")
+set("ISO639_1_NAME2CODE_Brazilian" "br")
+set("ISO639_1_NAME2CODE_Portuguese" "pt")
+set("ISO639_1_NAME2CODE_Brazilian-Portuguese" "${ISO639_1_NAME2CODE_Portuguese}-BR")
+
+set("ISO639_1_NAME2CODE_Esperanto" "eo")
+set("ISO639_1_NAME2CODE_Georgian" "ka")
+set("ISO639_1_NAME2CODE_Kyrgyz" "ky")
+set("ISO639_1_NAME2CODE_Tatar" "tt")
+
+
+set("VOICE_talgat_LICENSE" "Proprietary, non-commercial") # Tatar
+set("VOICE_natia_LICENSE" "Proprietary, personal use only") # Georgian
+set("VOICE_Leticia-F123_LICENSE" "by-sa-4.0") # Brazilian Portuguese
+
+set("VOICE_aleksandr_LANG" "ru")
+set("VOICE_anna_LANG" "ru")
+set("VOICE_elena_LANG" "ru")
+set("VOICE_irina_LANG" "ru")
+
+set("VOICE_alan_LANG" "en")
+set("VOICE_bdl_LANG" "en")
+set("VOICE_clb_LANG" "en")
+set("VOICE_slt_LANG" "en")
+
+set("VOICE_anatol_LANG" "uk")
+set("VOICE_natalia_LANG" "uk")
+
+set("VOICE_Leticia-F123_LANG" "${ISO639_1_NAME2CODE_Brazilian-Portuguese}")
+
+set("VOICE_spomenka_LANG" "eo")
+
+set("VOICE_natia_LANG" "ka")
+
+set("VOICE_azamat_LANG" "ky")
+set("VOICE_nazgul_LANG" "ky")
+
+set("VOICE_talgat_LANG" "tt")
+
+add_subdirectory("languages")
+add_subdirectory("voices")
+pass_through_cpack_vars()

--- a/data/languages/CMakeLists.txt
+++ b/data/languages/CMakeLists.txt
@@ -1,0 +1,63 @@
+set("CPACK_DEBIAN_LANGUAGES_PACKAGE_NAME" "rhvoice-languages" PARENT_SCOPE)
+
+macro(languageInDir languageName langDir)
+	set(lang_var_name "ISO639_1_NAME2CODE_${languageName}")
+
+	if(${lang_var_name})
+		set(langCode "${${lang_var_name}}")
+	else()
+		message(FATAL_ERROR "Please set ${lang_var_name} to the code of the lang from https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes")
+	endif()
+
+	set(languagePackageName "RHVoice-language-${langCode}")
+	file(GLOB_RECURSE SRCFILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "${langDir}/*")
+	add_custom_target(
+		"${languagePackageName}"
+		SOURCES "${SRCFILES}"
+	)
+
+	string(TOUPPER "${languagePackageName}" languagePackageNameUpper)
+	cpack_add_component("${languagePackageName}" GROUP "languages" DISPLAY_NAME "${languageName}"
+		DESCRIPTION "${languageName} language (${langCode}) for RHVoice"
+	)
+
+	set("CPACK_DEBIAN_${languagePackageNameUpper}_PACKAGE_NAME" "${languagePackageName}")
+	set("CPACK_RPM_${languagePackageNameUpper}_PACKAGE_NAME" "${languagePackageName}")
+	set("CPACK_DEBIAN_${languagePackageNameUpper}_PACKAGE_DEPENDS" "${CPACK_DEBIAN_CORE_PACKAGE_NAME}, RHVoice-language-${langCode}" PARENT_SCOPE)
+	set("CPACK_DEBIAN_${languagePackageNameUpper}_PACKAGE_SECTION" "contrib" PARENT_SCOPE)
+
+	install(DIRECTORY "${langDir}"
+		DESTINATION "${languages_dir}"
+		COMPONENT "${languagePackageName}"
+		PATTERN "SConscript" EXCLUDE
+		PATTERN "CMakeLists.txt" EXCLUDE
+	)
+	pass_through_cpack_vars()
+endmacro()
+
+
+#set("CPACK_DEBIAN_LANGUAGES_PACKAGE_NAME" "rhvoice-languages" PARENT_SCOPE)
+
+cpack_add_component_group("languages"
+	DISPLAY_NAME "Languages"
+	DESCRIPTION "Different languages"
+	PARENT_GROUP "data"
+	EXPANDED
+)
+
+file(GLOB languagesDirzInThisDir
+	LIST_DIRECTORIES true
+	"${CMAKE_CURRENT_SOURCE_DIR}/*"
+)
+foreach(langDir IN LISTS languagesDirzInThisDir)
+	if(IS_DIRECTORY "${langDir}")
+		get_filename_component(languageName "${langDir}" NAME)
+		if(EXISTS "${langDir}/CMakeLists.txt")
+			add_subdirectory("${langDir}")
+		else()
+			languageInDir("${languageName}" "${langDir}" )
+		endif()
+	endif()
+endforeach()
+
+pass_through_cpack_vars()

--- a/data/voices/CMakeLists.txt
+++ b/data/voices/CMakeLists.txt
@@ -1,0 +1,100 @@
+set("CPACK_DEBIAN_VOICES_PACKAGE_NAME" "rhvoice-voices" PARENT_SCOPE)
+
+macro(voiceInDir voiceName voiceDir)
+	set(lang_var_name "VOICE_${voiceName}_LANG")
+	set(lang_license_name "VOICE_${voiceName}_LICENSE")
+
+	if(${lang_var_name})
+		set(langCode "${${lang_var_name}}")
+	else()
+		message(FATAL_ERROR "Please set ${lang_var_name} to the code of the lang of the voice ${voiceName} from https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes")
+	endif()
+
+	if(${lang_license_name})
+		set(license "${${lang_license_name}}")
+	else()
+		set(license "lgpl-2.1")
+	endif()
+
+	set(voicePackageName "RHVoice-voice-${langCode}-${voiceName}")
+	file(GLOB_RECURSE SRCFILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "${voiceDir}/*")
+	add_custom_target(
+		"${voicePackageName}"
+		SOURCES "${SRCFILES}"
+	)
+
+	string(TOUPPER "${voicePackageName}" voicePackageNameUpper)
+	cpack_add_component("${voicePackageName}" GROUP "voices" DISPLAY_NAME "${voiceName}"
+		DESCRIPTION "${voiceName} voice for ${langCode} language for RHVoice licensed under `${license}` license."
+	)
+
+	set("CPACK_DEBIAN_${voicePackageNameUpper}_PACKAGE_NAME" "${voicePackageName}")
+	set("CPACK_RPM_${voicePackageNameUpper}_PACKAGE_NAME" "${voicePackageName}")
+	set("CPACK_DEBIAN_${voicePackageNameUpper}_PACKAGE_DEPENDS" "${CPACK_DEBIAN_CORE_PACKAGE_NAME}, RHVoice-language-${langCode}" PARENT_SCOPE)
+	set("CPACK_DEBIAN_${languagePackageNameUpper}_PACKAGE_SECTION" "contrib" PARENT_SCOPE)
+	
+	install(DIRECTORY "${voiceDir}"
+		DESTINATION "${voices_dir}"
+		COMPONENT "${voicePackageName}"
+		PATTERN "SConscript" EXCLUDE
+		PATTERN "CMakeLists.txt" EXCLUDE
+	)
+
+	set(licenseFileCandidate "${licenses_dir}/${license}.txt")
+	if(EXISTS "${licenseFileCandidate}")
+		install(FILES "${licenseFileCandidate}"
+			DESTINATION "${common_doc_dir}/${voiceName}/"
+			COMPONENT "${voicePackageName}"
+			RENAME "copyright"
+		)
+	else()
+		set(licenseDirCandidate "${voice_licenses_dir}/${voiceName}")
+		if(EXISTS "${licenseDirCandidate}")
+			file(GLOB_RECURSE licenseFiles RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "${licenseDirCandidate}/*")
+			list(LENGTH "${licenseFiles}" licenseFilesLen)
+			if(licenseFilesLen EQUAL "1")
+				install(FILES ${licenseFiles}
+					DESTINATION "${common_doc_dir}/${voiceName}/"
+					COMPONENT "${voicePackageName}"
+					RENAME "copyright"
+				)
+			else()
+				install(FILES ${licenseFiles}
+					DESTINATION "${common_doc_dir}/${voiceName}/"
+					COMPONENT "${voicePackageName}"
+				)
+			endif()
+		else()
+			message(FATAL_ERROR "License files are missing for the voice ${voiceName}!")
+		endif()
+	endif()
+
+	pass_through_cpack_vars()
+endmacro()
+
+
+#set("CPACK_DEBIAN_VOICES_PACKAGE_NAME" "rhvoice-voices" PARENT_SCOPE)
+
+cpack_add_component_group("voices"
+	DISPLAY_NAME "Voices"
+	DESCRIPTION "Different voices"
+	PARENT_GROUP "data"
+	EXPANDED
+)
+
+file(GLOB voicesDirzInThisDir
+	LIST_DIRECTORIES true
+	"${CMAKE_CURRENT_SOURCE_DIR}/*"
+)
+foreach(voiceDir IN LISTS voicesDirzInThisDir)
+	if(IS_DIRECTORY "${voiceDir}")
+		get_filename_component(voiceName "${voiceDir}" NAME)
+		if(EXISTS "${voiceDir}/CMakeLists.txt")
+			add_subdirectory("${voiceDir}")
+		else()
+			voiceInDir("${voiceName}" "${voiceDir}" )
+		endif()
+	endif()
+endforeach()
+
+pass_through_cpack_vars()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,23 @@
+set(INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/config.h.in" "${INCLUDE_DIR}/core/config.h")
+
+add_subdirectory("third-party")
+set(HTS_LABELS_KIT_INCLUDES "${UTF8_INCLUDE_DIR}" "${RAPIDXML_INCLUDE_DIR}")
+
+add_subdirectory("core")
+add_subdirectory("audio")
+add_subdirectory("lib")
+add_subdirectory("bin")
+add_subdirectory("utils")
+add_subdirectory("test")
+
+IF (WIN32)
+	#add_subdirectory("sapi")
+	#add_subdirectory("nvda-synthDriver")
+	#add_subdirectory("wininst")
+else()
+	add_subdirectory("service")
+	add_subdirectory("sd_module")
+endif()
+
+pass_through_cpack_vars()

--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -1,0 +1,65 @@
+# -*- mode: Python; indent-tabs-mode: t; tab-width: 4 -*-
+# Copyright (C) 2012, 2014, 2018  Olga Yakovleva <yakovleva.o.v@gmail.com>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set(SOURCES "audio.cpp;file_playback_stream_impl.cpp;playback_stream.cpp")
+
+set(audio_libs "libao;pulse;portaudio")
+
+pkg_check_modules(LIBAO "ao")
+pkg_check_modules(LIBPORTAUDIO "portaudio-2.0")
+pkg_check_modules(LIBPULSESIMPLE "libpulse-simple")
+option(WITH_LIBAO "Support libao" "${LIBAO_FOUND}")
+option(WITH_PULSE "Support pulseaudio" "${LIBPULSESIMPLE_FOUND}")
+option(WITH_PORTAUDIO "Support portaudio" "${LIBPORTAUDIO_FOUND}")
+
+if(WITH_LIBAO)
+	list(APPEND SOURCES "libao.cpp")
+endif()
+if(WITH_PULSE)
+	list(APPEND SOURCES "pulse.cpp")
+endif()
+if(WITH_PORTAUDIO)
+	list(APPEND SOURCES "portaudio.cpp")
+endif()
+
+add_library(RHVoice_audio SHARED "${SOURCES}")
+set_target_properties(RHVoice_audio PROPERTIES VERSION "${RHVOICE_VERSION}" SOVERSION "${RHVOICE_VERSION_MAJOR}")
+harden("RHVoice_audio")
+target_include_directories(RHVoice_audio PRIVATE "${INCLUDE_DIR}")
+
+if(WITH_LIBAO)
+	target_link_libraries(RHVoice_audio "${LIBAO_LIBRARIES}")
+	message(STATUS "${LIBAO_INCLUDE_DIRS}")
+	target_include_directories(RHVoice_audio PRIVATE "${LIBAO_INCLUDE_DIRS}")
+endif()
+if(WITH_PULSE)
+	target_compile_definitions(RHVoice_audio PUBLIC WITH_PULSE)
+	target_link_libraries(RHVoice_audio "${LIBPULSESIMPLE_LIBRARIES}")
+	target_include_directories(RHVoice_audio PRIVATE "${LIBPULSESIMPLE_INCLUDE_DIRS}")
+endif()
+if(WITH_PORTAUDIO)
+	target_compile_definitions(RHVoice_audio PUBLIC WITH_PORTAUDIO)
+	target_link_libraries(RHVoice_audio "${LIBPORTAUDIO_LIBRARIES}")
+	target_include_directories(RHVoice_audio PRIVATE "${LIBPORTAUDIO_INCLUDE_DIRS}")
+endif()
+
+install(TARGETS "RHVoice_audio"
+	LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+	COMPONENT "audio"
+)
+
+set("CPACK_DEBIAN_AUDIO_PACKAGE_NAME" "librhvoice-audio" PARENT_SCOPE)
+set(CPACK_DEBIAN_AUDIO_PACKAGE_DEPENDS "${CPACK_DEBIAN_CORE_PACKAGE_NAME}" PARENT_SCOPE)

--- a/src/audio/file_playback_stream_impl.cpp
+++ b/src/audio/file_playback_stream_impl.cpp
@@ -44,7 +44,7 @@ namespace RHVoice
       num_samples+=count;
     }
 
-    void file_playback_stream_impl::open(int sample_rate)
+    void file_playback_stream_impl::open(uint32_t sample_rate)
     {
       if(!piping)
         io::open_ofstream(fstream,file_path,true);

--- a/src/audio/file_playback_stream_impl.hpp
+++ b/src/audio/file_playback_stream_impl.hpp
@@ -29,7 +29,7 @@ namespace RHVoice
     public:
       explicit file_playback_stream_impl(const playback_params& params);
       void write(const short* samples,std::size_t count);
-      void open(int sample_rate);
+      void open(uint32_t sample_rate);
       bool is_open() const;
       void close();
 

--- a/src/audio/libao.cpp
+++ b/src/audio/libao.cpp
@@ -61,7 +61,7 @@ namespace RHVoice
       public:
         explicit libao_playback_stream_impl(const playback_params& params);
         void write(const short* samples,std::size_t count);
-        void open(int sample_rate);
+        void open(uint32_t sample_rate);
         bool is_open() const;
         void close();
 
@@ -106,9 +106,12 @@ namespace RHVoice
           throw backend_error();
       }
 
-    void libao_playback_stream_impl::open(int sample_rate)
+    void libao_playback_stream_impl::open(uint32_t sample_rate)
     {
-      ao_sample_format sample_format={16,sample_rate,1,AO_FMT_NATIVE,0};
+      if(sample_rate > std::numeric_limits<int>::max()){
+        throw disallowed_sample_rate();
+      }
+      ao_sample_format sample_format={16,static_cast<int>(sample_rate),1,AO_FMT_NATIVE,0};
       if(is_file)
         device_handle=ao_open_file(driver_id,device_name.c_str(),1,&sample_format,0);
       else

--- a/src/audio/playback_stream_impl.hpp
+++ b/src/audio/playback_stream_impl.hpp
@@ -29,7 +29,7 @@ namespace RHVoice
       {
       }
 
-      virtual void open(int sample_rate) =0;
+      virtual void open(uint32_t sample_rate) =0;
       virtual bool is_open() const=0;
       virtual void close()=0;
 

--- a/src/audio/portaudio.cpp
+++ b/src/audio/portaudio.cpp
@@ -31,7 +31,7 @@ namespace RHVoice
         void drain();
         void flush();
         void idle();
-        void open(int sample_rate);
+        void open(uint32_t sample_rate);
         bool is_open() const;
         void close();
 
@@ -90,7 +90,7 @@ namespace RHVoice
           throw backend_error();
       }
 
-    void portaudio_playback_stream_impl::open(int sample_rate)
+    void portaudio_playback_stream_impl::open(uint32_t sample_rate)
     {
       PaStreamParameters params;
       params.device=get_device();

--- a/src/audio/pulse.cpp
+++ b/src/audio/pulse.cpp
@@ -32,7 +32,7 @@ namespace RHVoice
         void write(const short* samples,std::size_t count);
         void drain();
         void flush();
-        void open(int sample_rate);
+        void open(uint32_t sample_rate);
         bool is_open() const;
         void close();
 
@@ -55,7 +55,7 @@ namespace RHVoice
           throw backend_error();
       }
 
-    void pulse_playback_stream_impl::open(int sample_rate)
+    void pulse_playback_stream_impl::open(uint32_t sample_rate)
     {
       pa_sample_spec sample_spec={PA_SAMPLE_S16NE,sample_rate,1};
       pa_buffer_attr attr={default_value,default_value,default_value,default_value,default_value};

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -1,0 +1,33 @@
+# -*- mode: Python; indent-tabs-mode: t; tab-width: 4 -*-
+# Copyright (C) 2012, 2014, 2018  Olga Yakovleva <yakovleva.o.v@gmail.com>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+add_executable("RHVoice-client" "${CMAKE_CURRENT_SOURCE_DIR}/rhvoice-client.c")
+target_link_libraries("RHVoice-client" "RHVoice_core")
+harden("RHVoice-client")
+target_compile_definitions("RHVoice-client" PRIVATE "-DVERSION=\"${VERSION}\"")
+
+#add_executable("RHVoice" "${CMAKE_CURRENT_SOURCE_DIR}/main.cpp")
+#target_link_libraries("RHVoice" "RHVoice_core")
+#target_compile_definitions(RHVoice PRIVATE "-DPACKAGE=\"RHVoice\"")
+#harden("RHVoice")
+
+install(TARGETS "RHVoice-client"
+	RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+	COMPONENT "client"
+)
+
+set("CPACK_DEBIAN_CLIENT_PACKAGE_NAME" "rhvoice-client" PARENT_SCOPE)
+set(CPACK_DEBIAN_CLIENT_PACKAGE_DEPENDS "${CPACK_DEBIAN_CORE_PACKAGE_NAME}, ${CPACK_DEBIAN_AUDIO_PACKAGE_NAME}" PARENT_SCOPE)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -1,0 +1,3 @@
+#cmakedefine01 ENABLE_MAGE
+
+const char VERSION[] = "@VERSION@";

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,0 +1,62 @@
+# -*- mode: Python; indent-tabs-mode: t; tab-width: 4 -*-
+# Copyright (C) 2012, 2018, 2019  Olga Yakovleva <yakovleva.o.v@gmail.com>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+file(GLOB_RECURSE SRCFILES "${CMAKE_CURRENT_SOURCE_DIR}/*.c" "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+
+# database files, included into needed places
+list(REMOVE_ITEM SRCFILES "${CMAKE_CURRENT_SOURCE_DIR}/emoji_data.cpp")
+list(REMOVE_ITEM SRCFILES "${CMAKE_CURRENT_SOURCE_DIR}/unidata.cpp")
+list(REMOVE_ITEM SRCFILES "${CMAKE_CURRENT_SOURCE_DIR}/userdict_parser.c")
+
+
+if(ENABLE_MAGE)
+	set(CPACK_DEBIAN_AUDIO_PACKAGE_DEPENDS "${CPACK_DEBIAN_LIBMAGE_PACKAGE_NAME}" PARENT_SCOPE)
+else()
+	list(REMOVE_ITEM SRCFILES "${CMAKE_CURRENT_SOURCE_DIR}/mage_hts_engine_impl.cpp")
+endif()
+
+add_library(RHVoice_core SHARED "${SRCFILES}")
+set_target_properties(RHVoice_core PROPERTIES VERSION "${RHVOICE_VERSION}" SOVERSION "${RHVOICE_VERSION_MAJOR}")
+set(libs2link "sonic" "libhts_engine")
+target_include_directories(RHVoice_core PUBLIC "${INCLUDE_DIR}" PRIVATE "${HTS_LABELS_KIT_INCLUDES}")
+
+set(package_name "RHVoice_core")
+
+if(WIN32)
+	set("DATA_PATH" "data")
+	set("CONFIG_PATH" "config")
+else()
+	set(DATA_PATH "${data_dir}")
+	set(CONFIG_PATH "${config_dir}")
+endif()
+
+set(VERSION "${RHVOICE_VERSION}")
+
+if(ENABLE_MAGE)
+	list(APPEND libs2link "libmage")
+endif()
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/config.h.in" "${CMAKE_CURRENT_SOURCE_DIR}/config.h")
+
+target_link_libraries(RHVoice_core "${libs2link}")
+harden("RHVoice_core")
+
+install(TARGETS "RHVoice_core"
+	LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+	COMPONENT "core"
+)
+
+set("CPACK_DEBIAN_CORE_PACKAGE_NAME" "librhvoice-core" PARENT_SCOPE)

--- a/src/core/brazilian_portuguese.cpp
+++ b/src/core/brazilian_portuguese.cpp
@@ -149,10 +149,10 @@ namespace RHVoice
             item& syls=word_iter->as("SylStructure");
             for(item::reverse_iterator syl_iter=syls.rbegin();syl_iter!=syls.rend();++syl_iter)
               {
-                if(syl_iter->get("stress").as<std::string>()!="1")
+                if((*syl_iter).get("stress").as<std::string>()!="1")
                   continue;
-                item::iterator vowel_pos=std::find_if(syl_iter->begin(),syl_iter->end(),feature_equals<std::string>("ph_vc","+"));
-                if(vowel_pos==syl_iter->end())
+                item::iterator vowel_pos=std::find_if((*syl_iter).begin(),(*syl_iter).end(),feature_equals<std::string>("ph_vc","+"));
+                if(vowel_pos==(*syl_iter).end())
                   break;
                 name=vowel_pos->get("name").as<std::string>();
                 if(h=="H1")

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -1,0 +1,2 @@
+const char CONFIG_PATH[] = "/etc/RHVoice";
+const char DATA_PATH[] = "/usr/share/RHVoice";

--- a/src/core/config.h.in
+++ b/src/core/config.h.in
@@ -1,0 +1,2 @@
+const char CONFIG_PATH[] = "@CONFIG_PATH@";
+const char DATA_PATH[] = "@DATA_PATH@";

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -16,6 +16,7 @@
 #include "core/path.hpp"
 #include "core/config.hpp"
 #include "core/engine.hpp"
+#include "config.h"
 
 namespace
 {

--- a/src/core/russian.cpp
+++ b/src/core/russian.cpp
@@ -379,10 +379,10 @@ namespace RHVoice
     relation& seg_rel=u.get_relation("Segment");
     for(relation::reverse_iterator seg_iter(seg_rel.rbegin());seg_iter!=seg_rel.rend();++seg_iter)
       {
-        if(seg_iter->in("Transcription")&&
-           seg_iter->as("Transcription").parent().has_feature("english"))
+        if((*seg_iter).in("Transcription")&&
+           (*seg_iter).as("Transcription").parent().has_feature("english"))
           continue;
-        std::string vpair=seg_iter->eval("ph_vpair").as<std::string>();
+        std::string vpair=(*seg_iter).eval("ph_vpair").as<std::string>();
         if(vpair!="0")
           {
             item& seg=*seg_iter;

--- a/src/include/audio.hpp
+++ b/src/include/audio.hpp
@@ -16,6 +16,7 @@
 #ifndef RHVOICE_AUDIO_HPP
 #define RHVOICE_AUDIO_HPP
 
+#include <limits>
 #include <string>
 #include <vector>
 #include <memory>
@@ -30,6 +31,14 @@ namespace RHVoice
     {
       explicit error(const std::string& msg):
         exception(msg)
+      {
+      }
+    };
+
+    struct disallowed_sample_rate: public error
+    {
+      disallowed_sample_rate():
+        error("This sample rate is unsupported")
       {
       }
     };

--- a/src/include/core/config.hpp
+++ b/src/include/core/config.hpp
@@ -16,6 +16,7 @@
 #ifndef RHVOICE_CONFIG_HPP
 #define RHVOICE_CONFIG_HPP
 
+#include "config.h"
 #include <string>
 #include <map>
 #include <memory>

--- a/src/include/core/sample_rate.hpp
+++ b/src/include/core/sample_rate.hpp
@@ -27,20 +27,22 @@ namespace RHVoice
       sample_rate_24k=24000,
       sample_rate_32k=32000,
       sample_rate_44k=44100,
-      sample_rate_48k=48000
+      sample_rate_48k=48000,
+      sample_rate_96k=96000
     };
 
   class sample_rate_property: public enum_property<sample_rate_t>
   {
   public:
     sample_rate_property():
-      enum_property<sample_rate_t>("sample_rate",sample_rate_24k)
+      enum_property<sample_rate_t>("sample_rate",sample_rate_48k)
     {
       define("16k",sample_rate_16k);
       define("22k",sample_rate_22k);
       define("32k",sample_rate_32k);
       define("44k",sample_rate_44k);
       define("48k",sample_rate_48k);
+      define("96k",sample_rate_96k);
     }
 
     sample_rate_property& operator=(sample_rate_t val)

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright (C) 2010, 2011, 2018, 2019  Olga Yakovleva <yakovleva.o.v@gmail.com>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+add_library(RHVoice SHARED "${CMAKE_CURRENT_SOURCE_DIR}/lib.cpp")
+set_target_properties(RHVoice PROPERTIES VERSION "${RHVOICE_VERSION}" SOVERSION "${RHVOICE_VERSION_MAJOR}")
+harden("RHVoice")
+target_include_directories(RHVoice PRIVATE "${INCLUDE_DIR}" "${HTS_LABELS_KIT_INCLUDES}")
+target_link_libraries("RHVoice" "RHVoice_core")
+
+install(TARGETS "RHVoice"
+	LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+	COMPONENT "lib"
+)
+
+set("CPACK_DEBIAN_LIB_PACKAGE_NAME" "librhvoice" PARENT_SCOPE)
+set(CPACK_DEBIAN_LIB_PACKAGE_DEPENDS "${CPACK_DEBIAN_CORE_PACKAGE_NAME}, ${CPACK_DEBIAN_AUDIO_PACKAGE_NAME}"  PARENT_SCOPE)

--- a/src/sd_module/CMakeLists.txt
+++ b/src/sd_module/CMakeLists.txt
@@ -1,0 +1,32 @@
+# -*- mode: Python; indent-tabs-mode: t; tab-width: 4 -*-
+# Copyright (C) 2012, 2018  Olga Yakovleva <yakovleva.o.v@gmail.com>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+file(GLOB_RECURSE SRCFILES "${CMAKE_CURRENT_SOURCE_DIR}/*.c" "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+add_executable(sd_rhvoice "${SRCFILES}")
+target_include_directories(sd_rhvoice PRIVATE "${INCLUDE_DIR}" "${HTS_LABELS_KIT_INCLUDES}")
+target_link_libraries(sd_rhvoice "RHVoice_core" "RHVoice_audio" pthread)
+harden(sd_rhvoice)
+
+set(SPEECH_DISPATCHER_MODULES_DIR "${CMAKE_INSTALL_PREFIX}/lib/speech-dispatcher-modules")
+
+install(TARGETS "sd_rhvoice"
+	RUNTIME DESTINATION "${SPEECH_DISPATCHER_MODULES_DIR}"
+	COMPONENT "sd_module"
+)
+
+set("CPACK_DEBIAN_SD_MODULE_PACKAGE_NAME" "speech-dispatcher-rhvoice" PARENT_SCOPE)
+set(CPACK_DEBIAN_SD_MODULE_PACKAGE_DEPENDS "${CPACK_DEBIAN_CORE_PACKAGE_NAME}, speech-dispatcher" PARENT_SCOPE)
+set(CPACK_DEBIAN_SD_MODULE_PACKAGE_SUGGESTS "spd-say, python3-speechd" PARENT_SCOPE)

--- a/src/service/CMakeLists.txt
+++ b/src/service/CMakeLists.txt
@@ -1,0 +1,41 @@
+# -*- mode: Python; indent-tabs-mode: t -*-
+# Copyright (C) 2012, 2018  Olga Yakovleva <yakovleva.o.v@gmail.com>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+#pkg_check_modules(LIBGLIMM REQUIRED glibmm-2.4)
+pkg_check_modules(LIBGIOMM REQUIRED giomm-2.4)
+
+add_executable("RHVoice-service" "${CMAKE_CURRENT_SOURCE_DIR}/service.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/common.cpp")
+target_include_directories("RHVoice-service" PRIVATE "${LIBGIOMM_INCLUDE_DIRS}" "${HTS_LABELS_KIT_INCLUDES}")
+target_link_libraries("RHVoice-service" "RHVoice_core" "${LIBGIOMM_LIBRARIES}")
+harden("RHVoice-service")
+
+install(TARGETS "RHVoice-service"
+	RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+	COMPONENT "service"
+)
+set(SERVICE_FILE_NAME "com.github.OlgaYakovleva.RHVoice.service")
+
+set(serviceInputFile "${CMAKE_CURRENT_SOURCE_DIR}/${SERVICE_FILE_NAME}.in")
+set(serviceOutputFile "${CMAKE_CURRENT_BINARY_DIR}/${SERVICE_FILE_NAME}")
+
+set(bindir "${BINDIR}")
+configure_file("${serviceInputFile}" "${serviceOutputFile}")
+install(FILES "${serviceOutputFile}"
+	DESTINATION "${servicedir}/systemd/system"
+	COMPONENT "service"
+)
+set("CPACK_DEBIAN_SERVICE_PACKAGE_NAME" "rhvoice-systemd-service" PARENT_SCOPE)

--- a/src/service/service.cpp
+++ b/src/service/service.cpp
@@ -508,7 +508,7 @@ namespace
   void on_name_vanished(const Glib::RefPtr<Gio::DBus::Connection>& connection,const Glib::ustring& name)
   {
     session_ptr session_to_close=get_session(connection,name);
-    if(!session_to_close.empty())
+    if(session_to_close)
       session_to_close->close();
   }
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,0 +1,27 @@
+# -*- mode: Python; indent-tabs-mode: t; tab-width: 4 -*-
+# Copyright (C) 2012, 2014, 2018  Olga Yakovleva <yakovleva.o.v@gmail.com>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+add_executable("RHVoice-test" "${CMAKE_CURRENT_SOURCE_DIR}/test.cpp")
+target_link_libraries("RHVoice-test" "RHVoice" "RHVoice_audio")
+target_include_directories("RHVoice-test" PRIVATE "${TCLAP_INCLUDE_DIR}" "${HTS_LABELS_KIT_INCLUDES}")
+harden("RHVoice-test")
+
+install(TARGETS "RHVoice-test"
+	RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+	COMPONENT "test"
+)
+set("CPACK_DEBIAN_TEST_PACKAGE_NAME" "rhvoice-test" PARENT_SCOPE)
+set(CPACK_DEBIAN_TEST_PACKAGE_DEPENDS "${CPACK_DEBIAN_CORE_PACKAGE_NAME}, ${CPACK_DEBIAN_AUDIO_PACKAGE_NAME}" PARENT_SCOPE)

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -115,6 +115,7 @@ int main(int argc,const char* argv[])
       TCLAP::SwitchArg ssml_switch("s","ssml","Process as ssml",cmd,false);
       TCLAP::ValueArg<std::string> voice_arg("p","profile","voice profile",false,"","spec",cmd);
       TCLAP::ValueArg<unsigned int> rate_arg("r","rate","speech rate",false,100,"percent",cmd);
+      TCLAP::ValueArg<uint32_t> sample_rate("R","sample-rate","sample rate",false, 24000,"Hz",cmd);
       TCLAP::ValueArg<unsigned int> pitch_arg("t","pitch","speech pitch",false,100,"percent",cmd);
       TCLAP::ValueArg<unsigned int> volume_arg("v","volume","speech volume",false,100,"percent",cmd);
       cmd.parse(argc,argv);
@@ -126,6 +127,7 @@ int main(int argc,const char* argv[])
             throw std::runtime_error("Cannot open the input file");
         }
       audio_player player(outpath_arg.getValue());
+      player.set_sample_rate(sample_rate.getValue());
       player.set_buffer_size(20);
       std::shared_ptr<engine> eng(new engine);
       voice_profile profile;

--- a/src/third-party/CMakeLists.txt
+++ b/src/third-party/CMakeLists.txt
@@ -1,0 +1,28 @@
+# -*- mode: Python; indent-tabs-mode: t; tab-width: 4; python-indent: 4 -*-
+# Copyright (C) 2013  Olga Yakovleva <yakovleva.o.v@gmail.com>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+if(ENABLE_MAGE)
+	add_subdirectory("mage")
+endif()
+
+add_subdirectory("sonic")
+add_subdirectory("hts_engine")
+
+set(UTF8_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/utf8" PARENT_SCOPE)
+set(RAPIDXML_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/rapidxml" PARENT_SCOPE)
+set(TCLAP_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/tclap" PARENT_SCOPE)
+
+pass_through_cpack_vars()

--- a/src/third-party/hts_engine/CMakeLists.txt
+++ b/src/third-party/hts_engine/CMakeLists.txt
@@ -1,0 +1,47 @@
+# -*- mode: Python; indent-tabs-mode: t; tab-width: 4; python-indent: 4 -*-
+# Copyright (C) 2013  Olga Yakovleva <yakovleva.o.v@gmail.com>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+file(GLOB_RECURSE SRCFILES1 "${CMAKE_CURRENT_SOURCE_DIR}/HTS_*.c")
+
+if(ENABLE_MAGE)
+	file(GLOB_RECURSE SRCFILES2 "${CMAKE_CURRENT_SOURCE_DIR}/HTS106_*.c")
+	set(CPACK_DEBIAN_LIBHTS_ENGINE_PACKAGE_DEPENDS "${CPACK_DEBIAN_LIBMAGE_PACKAGE_NAME}" PARENT_SCOPE)
+else()
+	set(SRCFILES2 "")
+endif()
+
+add_library(libhts_engine SHARED "${SRCFILES1}" "${SRCFILES2}")
+
+set(LIBHTS_VERSION_MAJOR 1)
+set(LIBHTS_VERSION_MINOR 06)
+set(LIBHTS_VERSION_PATCH 0)
+set(LIBHTS_VERSION "${LIBHTS_VERSION_MAJOR}.${LIBHTS_VERSION_MINOR}-RHVoice")
+set_target_properties(libhts_engine PROPERTIES VERSION "${LIBHTS_VERSION}" SOVERSION "${LIBHTS_VERSION_MAJOR}")
+
+set(CPACK_COMPONENT_LIBHTS_ENGINE_VERSION_MAJOR "${LIBHTS_VERSION_MAJOR}" PARENT_SCOPE)
+set(CPACK_COMPONENT_LIBHTS_ENGINE_VERSION_MINOR "${LIBHTS_VERSION_MINOR}" PARENT_SCOPE)
+set(CPACK_COMPONENT_LIBHTS_ENGINE_VERSION_PATCH "${LIBHTS_VERSION_PATCH}" PARENT_SCOPE)
+set(CPACK_COMPONENT_LIBHTS_ENGINE_VERSION "${LIBHTS_VERSION}" PARENT_SCOPE)
+
+target_include_directories(libhts_engine PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}" "${INCLUDE_DIR}")
+harden(libhts_engine)
+set_target_properties("libhts_engine" PROPERTIES PREFIX "")
+
+install(TARGETS "libhts_engine"
+	LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+	COMPONENT "libhts_engine"
+)
+set("CPACK_DEBIAN_LIBHTS_ENGINE_PACKAGE_NAME" "libhtsengine" PARENT_SCOPE)

--- a/src/third-party/mage/CMakeLists.txt
+++ b/src/third-party/mage/CMakeLists.txt
@@ -1,0 +1,41 @@
+# -*- mode: Python; indent-tabs-mode: t; tab-width: 4; python-indent: 4 -*-
+# Copyright (C) 2013  Olga Yakovleva <yakovleva.o.v@gmail.com>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+file(GLOB_RECURSE SRCFILES "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+add_library(libmage SHARED "${SRCFILES}")
+
+set(LIBMAGE_VERSION_MAJOR "2")
+set(LIBMAGE_VERSION_MINOR "0")
+set(LIBMAGE_VERSION_PATCH "0")
+set(LIBMAGE_VERSION "${LIBMAGE_VERSION_MAJOR}.${LIBMAGE_VERSION_MINOR}-RHVoice")
+set_target_properties(libmage PROPERTIES VERSION "${LIBMAGE_VERSION}" SOVERSION "${LIBMAGE_VERSION_MAJOR}")
+
+set(CPACK_COMPONENT_LIBMAGE_VERSION_MAJOR "${LIBMAGE_VERSION_MAJOR}" PARENT_SCOPE)
+set(CPACK_COMPONENT_LIBMAGE_VERSION_MINOR "${LIBMAGE_VERSION_MINOR}" PARENT_SCOPE)
+set(CPACK_COMPONENT_LIBMAGE_VERSION_PATCH "${LIBMAGE_VERSION_PATCH}" PARENT_SCOPE)
+set(CPACK_COMPONENT_LIBMAGE_VERSION "${LIBMAGE_VERSION}" PARENT_SCOPE)
+
+target_include_directories(libmage PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(libmage "libhts_engine")
+harden(libmage)
+set_target_properties("libmage" PROPERTIES PREFIX "")
+target_compile_definitions(libmage PRIVATE RHVOICE)
+install(TARGETS "libmage"
+	COMPONENT "libmage"
+	LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+)
+set("CPACK_DEBIAN_LIBMAGE_PACKAGE_NAME" "libmage" PARENT_SCOPE)
+set(CPACK_DEBIAN_LIBMAGE_PACKAGE_DEPENDS "${CPACK_DEBIAN_LIBHTS_ENGINE_PACKAGE_NAME}" PARENT_SCOPE)

--- a/src/third-party/sonic/CMakeLists.txt
+++ b/src/third-party/sonic/CMakeLists.txt
@@ -1,0 +1,37 @@
+# -*- mode: Python; indent-tabs-mode: t; tab-width: 4; python-indent: 4 -*-
+# Copyright (C) 2013  Olga Yakovleva <yakovleva.o.v@gmail.com>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+add_library(sonic SHARED "${CMAKE_CURRENT_SOURCE_DIR}/sonic.c")
+
+set(LIBSONIC_VERSION_MAJOR "0")
+set(LIBSONIC_VERSION_MINOR "1")
+set(LIBSONIC_VERSION_PATCH "17")
+set(LIBSONIC_VERSION "${LIBSONIC_VERSION_MAJOR}.${LIBSONIC_VERSION_MINOR}.${LIBSONIC_VERSION_PATCH}")
+
+set_target_properties(sonic PROPERTIES VERSION "${LIBSONIC_VERSION}" SOVERSION "${LIBSONIC_VERSION_MAJOR}")
+set(CPACK_COMPONENT_LIBSONIC_VERSION_MAJOR "${LIBSONIC_VERSION_MAJOR}" PARENT_SCOPE)
+set(CPACK_COMPONENT_LIBSONIC_VERSION_MINOR "${LIBSONIC_VERSION_MINOR}" PARENT_SCOPE)
+set(CPACK_COMPONENT_LIBSONIC_VERSION_PATCH "${LIBSONIC_VERSION_PATCH}" PARENT_SCOPE)
+set(CPACK_COMPONENT_LIBSONIC_VERSION "${LIBSONIC_VERSION}" PARENT_SCOPE)
+
+target_include_directories(sonic PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+harden(sonic)
+
+install(TARGETS "sonic"
+	COMPONENT "libsonic"
+	LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+)
+set(CPACK_DEBIAN_LIBSONIC_PACKAGE_NAME "libsonic" PARENT_SCOPE)

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,0 +1,34 @@
+# -*- mode: Python; indent-tabs-mode: t -*-
+# Copyright (C) 2012, 2018  Olga Yakovleva <yakovleva.o.v@gmail.com>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+add_executable("RHVoice-transcribe-sentences" "${CMAKE_CURRENT_SOURCE_DIR}/transcribe-sentences.cpp")
+target_include_directories("RHVoice-transcribe-sentences" PRIVATE "${TCLAP_INCLUDE_DIR}" "${HTS_LABELS_KIT_INCLUDES}" )
+target_link_libraries("RHVoice-transcribe-sentences" "RHVoice_core")
+harden("RHVoice-transcribe-sentences")
+
+add_executable("RHVoice-make-hts-labels" "${CMAKE_CURRENT_SOURCE_DIR}/make-hts-labels.cpp")
+target_include_directories("RHVoice-make-hts-labels" PRIVATE "${TCLAP_INCLUDE_DIR}" "${HTS_LABELS_KIT_INCLUDES}" )
+target_link_libraries("RHVoice-make-hts-labels" "RHVoice_core" "libhts_engine")
+harden("RHVoice-make-hts-labels")
+
+install(TARGETS "RHVoice-transcribe-sentences" "RHVoice-make-hts-labels"
+	RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+	COMPONENT "utils"
+)
+
+set("CPACK_DEBIAN_UTILS_PACKAGE_NAME" "rhvoice-tools" PARENT_SCOPE)
+set(CPACK_DEBIAN_UTILS_PACKAGE_DEPENDS "${CPACK_DEBIAN_CORE_PACKAGE_NAME}, ${CPACK_DEBIAN_AUDIO_PACKAGE_NAME}" PARENT_SCOPE)


### PR DESCRIPTION
Translated the scons build-scripts to CMake.
Added support of compiler-based mitigations against various attacks (DEP, ASLR, Spectre resistance) via my CMake script .
Implemented creation of packages (for Debian, for RPM-based distros I haven't tested) for components suitable for Linux-based OSes.
Added sample rate parameter to RHVoice-test (though it doesn't really work).
Added 96k to the list of sample rates (though it turned out that even 48k is not supported).

What DOES NOT WORK:
* RHVoice built without MAGE crashes IDK why
* building SAPI5 and NVDA modules is not yet implemented.
* **UNDEFINED BEHAVIOR HAS BEEN DETECTED IN THE SOURCE** Probably a use-before-init vulnr. When compiled with CLang (11, latest from the official apt) this shit sigsegvs. When compiled with g++ 9 it works. I guess this shit must be rewritten to rust. https://github.com/jameysharp/corrode may be helpful. At least you should hardcorely valgrind, ASan and UBSan it.

Closes: #151
Closes: #88