### PR TITLE
Replacing auto_ptr with shared_ptr, fixing several invalid usecases

### DIFF
--- a/src/android/RHVoice-core/src/main/jni/native.cpp
+++ b/src/android/RHVoice-core/src/main/jni/native.cpp
@@ -315,7 +315,7 @@ namespace
     if(profile.empty())
       throw voice_not_found();
     std::string text=jstring_to_string(env,input);
-    std::auto_ptr<document> doc;
+    std::unique_ptr<document> doc;
     if(check(env,env->CallBooleanMethod(params,SynthesisParameters_getSSMLMode_method)))
       doc=document::create_from_ssml(data->engine_ptr,text.begin(),text.end(),profile);
     else
@@ -440,7 +440,7 @@ JNIEXPORT void JNICALL Java_com_github_olga_1yakovleva_rhvoice_TTSEngine_onInit
 {
   TRY
   clear_native_field(env,obj,data_field);
-  std::auto_ptr<Data> data(new Data);
+  std::unique_ptr<Data> data(new Data);
   engine::init_params params;
   params.data_path=jstring_to_string(env,data_path);
   params.config_path=jstring_to_string(env,config_path);

--- a/src/audio/SConscript
+++ b/src/audio/SConscript
@@ -20,7 +20,7 @@ Import("env","libcore")
 local_env=env.Clone()
 local_env["libversion"]="1.1.0"
 local_env["liblevel"]=1
-src=["audio.cpp", "file_playback_stream_impl.cpp"]
+src=["audio.cpp", "file_playback_stream_impl.cpp", "playback_stream.cpp"]
 if "libao" in local_env["audio_libs"]:
 	src.append("libao.cpp")
 	local_env.Append(CPPDEFINES=("WITH_LIBAO","1"))

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -77,12 +77,12 @@ namespace RHVoice
     {
       if(impl.get()==0)
         {
-          std::auto_ptr<playback_stream_impl> new_impl;
+          std::unique_ptr<playback_stream_impl> new_impl;
           if(params.backend==backend_file)
             {
               new_impl.reset(new file_playback_stream_impl(params));
               new_impl->open(params.sample_rate);
-              impl=new_impl;
+              impl.reset(new_impl.release());
               return;
             }
           for(std::vector<smart_ptr<library> >::iterator it=libraries.begin();it!=libraries.end();++it)
@@ -95,7 +95,7 @@ namespace RHVoice
                     {
                       new_impl.reset((*it)->new_playback_stream_impl(params));
                       new_impl->open(params.sample_rate);
-                      impl=new_impl;
+                      impl.reset(new_impl.release());
                       return;
                     }
                   catch(const error& e)
@@ -106,7 +106,7 @@ namespace RHVoice
                 {
                   new_impl.reset((*it)->new_playback_stream_impl(params));
                   new_impl->open(params.sample_rate);
-                  impl=new_impl;
+                  impl.reset(new_impl.release());
                   return;
                 }
             }

--- a/src/audio/playback_stream.cpp
+++ b/src/audio/playback_stream.cpp
@@ -1,0 +1,17 @@
+#include "audio.hpp"
+#include "playback_stream_impl.hpp"
+
+using namespace RHVoice::audio;
+
+playback_stream::playback_stream(const playback_params& params_):
+  params(params_),
+  impl(nullptr)
+{
+}
+
+playback_stream::~playback_stream()
+{
+  if(is_open())
+    close();
+}
+

--- a/src/core/document.cpp
+++ b/src/core/document.cpp
@@ -206,10 +206,10 @@ namespace RHVoice
     return result;
   }
 
-  std::auto_ptr<utterance> sentence::new_utterance() const
+  std::unique_ptr<utterance> sentence::new_utterance() const
   {
     const voice_profile& profile=parent->get_voice_profile();
-    std::auto_ptr<utterance> u;
+    std::unique_ptr<utterance> u;
     const language_list& languages=parent->get_engine().get_languages();
     language_list::const_iterator current_language=language_and_voice.first;
     const voice_list& voices=parent->get_engine().get_voices();
@@ -345,9 +345,9 @@ namespace RHVoice
     subtoken.set("verbosity",level);
   }
 
-  std::auto_ptr<utterance> sentence::create_utterance(sentence_position pos) const
+  std::unique_ptr<utterance> sentence::create_utterance(sentence_position pos) const
   {
-    std::auto_ptr<utterance> u=new_utterance();
+    std::unique_ptr<utterance> u=new_utterance();
     apply_speech_settings(*u);
     execute_commands(*u);
     if(pos==sentence_position_single)
@@ -383,7 +383,7 @@ namespace RHVoice
   {
     if(!has_owner())
       return;
-    std::auto_ptr<utterance> u;
+    std::unique_ptr<utterance> u;
     sentence_position pos=sentence_position_initial;
     for(iterator it(begin());it!=end();++it)
       {

--- a/src/core/emoji.cpp
+++ b/src/core/emoji.cpp
@@ -48,13 +48,13 @@ namespace RHVoice
     class initial_scanner_state: public emoji_scanner_state
     {
     public:
-      std::auto_ptr<emoji_scanner_state> next(emoji_char_t c) const;
+      std::unique_ptr<emoji_scanner_state> next(emoji_char_t c) const;
     };
 
     class first_ri_scanner_state: public emoji_scanner_state
     {
     public:
-      std::auto_ptr<emoji_scanner_state> next(emoji_char_t c) const;
+      std::unique_ptr<emoji_scanner_state> next(emoji_char_t c) const;
     };
 
     class second_ri_scanner_state: public emoji_scanner_state
@@ -66,13 +66,13 @@ namespace RHVoice
     class first_keycap_seq_scanner_state: public emoji_scanner_state
     {
     public:
-      std::auto_ptr<emoji_scanner_state> next(emoji_char_t c) const;
+      std::unique_ptr<emoji_scanner_state> next(emoji_char_t c) const;
     };
 
     class second_keycap_seq_scanner_state: public emoji_scanner_state
     {
     public:
-      std::auto_ptr<emoji_scanner_state> next(emoji_char_t c) const;
+      std::unique_ptr<emoji_scanner_state> next(emoji_char_t c) const;
     };
 
     class third_keycap_seq_scanner_state: public emoji_scanner_state
@@ -84,7 +84,7 @@ namespace RHVoice
     class tag_spec_scanner_state: public emoji_scanner_state
     {
     public:
-      std::auto_ptr<emoji_scanner_state> next(emoji_char_t c) const;
+      std::unique_ptr<emoji_scanner_state> next(emoji_char_t c) const;
     };
 
     class tag_term_scanner_state: public emoji_scanner_state
@@ -96,7 +96,7 @@ namespace RHVoice
     class zwj_element_scanner_state: public emoji_scanner_state
     {
     public:
-      std::auto_ptr<emoji_scanner_state> next(emoji_char_t c) const;
+      std::unique_ptr<emoji_scanner_state> next(emoji_char_t c) const;
       bool can_end_emoji() const;
 
     protected:
@@ -116,7 +116,7 @@ namespace RHVoice
       {
 }
 
-      std::auto_ptr<emoji_scanner_state> next(emoji_char_t c) const;
+      std::unique_ptr<emoji_scanner_state> next(emoji_char_t c) const;
 
     private:
       emoji_char_t chr;
@@ -143,12 +143,12 @@ namespace RHVoice
     class zwj_scanner_state: public emoji_scanner_state
     {
     public:
-      std::auto_ptr<emoji_scanner_state> next(emoji_char_t c) const;
+      std::unique_ptr<emoji_scanner_state> next(emoji_char_t c) const;
     };
 
-    std::auto_ptr<emoji_scanner_state> initial_scanner_state::next(emoji_char_t c) const
+    std::unique_ptr<emoji_scanner_state> initial_scanner_state::next(emoji_char_t c) const
     {
-      std::auto_ptr<emoji_scanner_state> res;
+      std::unique_ptr<emoji_scanner_state> res;
       if(is_regional_indicator(c))
         res.reset(new first_ri_scanner_state);
       else if(c.p&emoji_property_emoji)
@@ -161,9 +161,9 @@ namespace RHVoice
       return res;
 }
 
-    std::auto_ptr<emoji_scanner_state> zwj_element_scanner_state::next(emoji_char_t c) const
+    std::unique_ptr<emoji_scanner_state> zwj_element_scanner_state::next(emoji_char_t c) const
     {
-      std::auto_ptr<emoji_scanner_state> res;
+      std::unique_ptr<emoji_scanner_state> res;
       if(c.cp==zwj)
         res.reset(new zwj_scanner_state);
       else if(first&&is_tag_spec_char(c))
@@ -176,9 +176,9 @@ namespace RHVoice
       return true;
 }
 
-    std::auto_ptr<emoji_scanner_state> emoji_char_scanner_state::next(emoji_char_t c) const
+    std::unique_ptr<emoji_scanner_state> emoji_char_scanner_state::next(emoji_char_t c) const
     {
-      std::auto_ptr<emoji_scanner_state> res(zwj_element_scanner_state::next(c));
+      std::unique_ptr<emoji_scanner_state> res(zwj_element_scanner_state::next(c));
       if(res.get()!=0)
         return res;
       if(c.cp==emoji_presentation_selector)
@@ -188,17 +188,17 @@ namespace RHVoice
       return res;
 }
 
-    std::auto_ptr<emoji_scanner_state> zwj_scanner_state::next(emoji_char_t c) const
+    std::unique_ptr<emoji_scanner_state> zwj_scanner_state::next(emoji_char_t c) const
     {
-      std::auto_ptr<emoji_scanner_state> res;
+      std::unique_ptr<emoji_scanner_state> res;
       if((c.p&emoji_property_emoji)&&!is_key_char(c))
         res.reset(new emoji_char_scanner_state(c,false));
       return res;
 }
 
-    std::auto_ptr<emoji_scanner_state> first_ri_scanner_state::next(emoji_char_t c) const
+    std::unique_ptr<emoji_scanner_state> first_ri_scanner_state::next(emoji_char_t c) const
     {
-      std::auto_ptr<emoji_scanner_state> res;
+      std::unique_ptr<emoji_scanner_state> res;
       if(is_regional_indicator(c))
         res.reset(new second_ri_scanner_state);
       return res;
@@ -209,17 +209,17 @@ namespace RHVoice
       return true;
 }
 
-    std::auto_ptr<emoji_scanner_state> first_keycap_seq_scanner_state::next(emoji_char_t c) const
+    std::unique_ptr<emoji_scanner_state> first_keycap_seq_scanner_state::next(emoji_char_t c) const
     {
-      std::auto_ptr<emoji_scanner_state> res;
+      std::unique_ptr<emoji_scanner_state> res;
       if(c.cp==emoji_presentation_selector)
         res.reset(new second_keycap_seq_scanner_state);
       return res;
 }
 
-    std::auto_ptr<emoji_scanner_state> second_keycap_seq_scanner_state::next(emoji_char_t c) const
+    std::unique_ptr<emoji_scanner_state> second_keycap_seq_scanner_state::next(emoji_char_t c) const
     {
-      std::auto_ptr<emoji_scanner_state> res;
+      std::unique_ptr<emoji_scanner_state> res;
       if(c.cp==keycap)
         res.reset(new third_keycap_seq_scanner_state);
       return res;
@@ -230,9 +230,9 @@ namespace RHVoice
       return true;
 }
 
-    std::auto_ptr<emoji_scanner_state> tag_spec_scanner_state::next(emoji_char_t c) const
+    std::unique_ptr<emoji_scanner_state> tag_spec_scanner_state::next(emoji_char_t c) const
     {
-      std::auto_ptr<emoji_scanner_state> res;
+      std::unique_ptr<emoji_scanner_state> res;
       if(c.cp==cancel_tag)
         res.reset(new tag_term_scanner_state);
       else if(is_tag_spec_char(c))
@@ -273,10 +273,10 @@ namespace RHVoice
     emoji_char_t c=find_emoji_char(cp);
     if(!c.valid())
       return false;
-    std::auto_ptr<emoji_scanner_state> new_state=state->next(c);
+    std::unique_ptr<emoji_scanner_state> new_state=state->next(c);
     if(new_state.get()==0)
       return false;
-    state=new_state;
+    state.reset(new_state.release());
     ++length;
     if(state->can_end_emoji())
       result=length;

--- a/src/core/userdict.cpp
+++ b/src/core/userdict.cpp
@@ -153,7 +153,7 @@ namespace RHVoice
         {
         }
 
-        std::auto_ptr<token> get_next_token();
+        std::unique_ptr<token> get_next_token();
 
       private:
         lexer(const lexer&);
@@ -330,7 +330,7 @@ namespace RHVoice
 
         const language_info& lang;
         const chars32& input;
-        std::auto_ptr<token> next_token;
+        std::unique_ptr<token> next_token;
         chars32::const_iterator pos;
       };
 
@@ -339,7 +339,7 @@ namespace RHVoice
       public:
         compiler(const language_info& lng,const std::string& file_path);
         ~compiler();
-        std::auto_ptr<ruleset> compile();
+        std::unique_ptr<ruleset> compile();
 
       private:
         compiler(const compiler&);
@@ -352,10 +352,10 @@ namespace RHVoice
         void* parser;
       };
 
-      std::auto_ptr<token> lexer::get_next_token()
+      std::unique_ptr<token> lexer::get_next_token()
       {
         if(pos==input.end())
-          return std::auto_ptr<token>();
+          return std::unique_ptr<token>();
         next_token.reset(new token);
         match_native_letters()||
           match_english_letters()||
@@ -373,7 +373,7 @@ namespace RHVoice
           match_newline()||
           match_comment()||
           match_symbol();
-        return next_token;
+        return std::move(next_token);
       }
     }
 
@@ -394,11 +394,11 @@ namespace RHVoice
       userdictParseFree(parser,std::free);
     }
 
-    std::auto_ptr<ruleset> compiler::compile()
+    std::unique_ptr<ruleset> compiler::compile()
     {
       lexer lxr(lang,source);
       parse_state ps;
-      std::auto_ptr<token> tok;
+      std::unique_ptr<token> tok;
       while((tok=lxr.get_next_token()).get()!=0)
         {
           int type=tok->get_type();
@@ -411,7 +411,7 @@ namespace RHVoice
               ps.error=false;
             }
         }
-      return ps.result;
+      return std::move(ps.result);
     }
 
     void compiler::read_source(const std::string& file_path)
@@ -464,7 +464,7 @@ namespace RHVoice
       try
         {
           compiler comp(lang,file_path);
-          std::auto_ptr<ruleset> result(comp.compile());
+          std::unique_ptr<ruleset> result(comp.compile());
           for(ruleset::iterator it=result->begin();it!=result->end();++it)
             {
               chars32 key=it->get_key();

--- a/src/include/audio.hpp
+++ b/src/include/audio.hpp
@@ -140,17 +140,9 @@ namespace RHVoice
     class playback_stream
     {
     public:
-      explicit playback_stream(const playback_params& params_=playback_params()):
-        params(params_),
-        impl(0)
-      {
-      }
+      explicit playback_stream(const playback_params& params_=playback_params());
 
-      ~playback_stream()
-      {
-        if(is_open())
-          close();
-      }
+      ~playback_stream();
 
       bool is_initialized() const
       {
@@ -239,7 +231,7 @@ namespace RHVoice
       static std::vector<smart_ptr<library> > init_libraries();
 
       playback_params params;
-      std::auto_ptr<playback_stream_impl> impl;
+      std::unique_ptr<playback_stream_impl> impl;
       static std::vector<smart_ptr<library> > libraries;
     };
 

--- a/src/include/core/brazilian_portuguese.hpp
+++ b/src/include/core/brazilian_portuguese.hpp
@@ -66,7 +66,7 @@ namespace RHVoice
     const brazilian_portuguese_info& info;
     const fst g2p_fst;
     const fst lseq_fst;
-    std::auto_ptr<fst> h_fst;
+    std::unique_ptr<fst> h_fst;
   };
 }
 #endif

--- a/src/include/core/document.hpp
+++ b/src/include/core/document.hpp
@@ -252,7 +252,7 @@ namespace RHVoice
       return commands.empty();
     }
 
-    std::auto_ptr<utterance> create_utterance(sentence_position position) const;
+    std::unique_ptr<utterance> create_utterance(sentence_position position) const;
 
     template<typename text_iterator>
     text_iterator add_text(const text_iterator& text_start,const text_iterator& text_end,const tts_markup& markup_info);
@@ -283,7 +283,7 @@ namespace RHVoice
     bool next_token_starts_new_sentence(const tts_markup& markup_info) const;
     voice_list::const_iterator determine_next_token_voice() const;
     language_voice_pair get_language_and_voice_from_markup(const tts_markup& markup_info) const;
-    std::auto_ptr<utterance> new_utterance() const;
+    std::unique_ptr<utterance> new_utterance() const;
     void execute_commands(utterance& u) const;
     void apply_speech_settings(utterance& u) const;
     void set_spell_single_symbol(utterance& u) const;
@@ -355,7 +355,7 @@ namespace RHVoice
 }
 
     template<typename some_iterator>
-    static std::auto_ptr<document> create_from_plain_text(const smart_ptr<engine>& engine_ptr,const some_iterator& text_start,const some_iterator& text_end,content_type say_as=content_text,const voice_profile& profile=voice_profile())
+    static std::unique_ptr<document> create_from_plain_text(const smart_ptr<engine>& engine_ptr,const some_iterator& text_start,const some_iterator& text_end,content_type say_as=content_text,const voice_profile& profile=voice_profile())
     {
       #ifdef _MSC_VER
       return create_from_plain_text(engine_ptr,text_start,text_end,say_as,profile,std::iterator_traits<some_iterator>::iterator_category());
@@ -365,7 +365,7 @@ namespace RHVoice
     }
 
     template<typename input_iterator>
-    static std::auto_ptr<document> create_from_ssml(const smart_ptr<engine>& engine_ptr,const input_iterator& text_start,const input_iterator& text_end,const voice_profile& profile=voice_profile());
+    static std::unique_ptr<document> create_from_ssml(const smart_ptr<engine>& engine_ptr,const input_iterator& text_start,const input_iterator& text_end,const voice_profile& profile=voice_profile());
 
     typedef std::list<sentence>::iterator iterator;
     typedef std::list<sentence>::const_iterator const_iterator;
@@ -427,7 +427,7 @@ namespace RHVoice
     }
 
     template<typename input_iterator>
-    static std::auto_ptr<document> create_from_plain_text(const smart_ptr<engine>& engine_ptr,const input_iterator& text_start,const input_iterator& text_end,content_type say_as,const voice_profile& profile,std::input_iterator_tag)
+    static std::unique_ptr<document> create_from_plain_text(const smart_ptr<engine>& engine_ptr,const input_iterator& text_start,const input_iterator& text_end,content_type say_as,const voice_profile& profile,std::input_iterator_tag)
     {
       #ifdef _MSC_VER
       typedef std::iterator_traits<input_iterator>::value_type char_type;
@@ -437,7 +437,7 @@ namespace RHVoice
       std::vector<char_type> tmp_buf(text_start,text_end);
       tts_markup m;
       m.say_as=say_as;
-      std::auto_ptr<document> doc_ptr(new document(engine_ptr,profile));
+      std::unique_ptr<document> doc_ptr(new document(engine_ptr,profile));
       #ifdef _MSC_VER
       typedef utf::text_iterator<std::vector<char_type>::const_iterator> char_iterator;
       #else
@@ -448,9 +448,9 @@ namespace RHVoice
     }
 
     template<typename forward_iterator>
-    static std::auto_ptr<document> create_from_plain_text(const smart_ptr<engine>& engine_ptr,const forward_iterator& text_start,const forward_iterator& text_end,content_type say_as,const voice_profile& profile,std::forward_iterator_tag)
+    static std::unique_ptr<document> create_from_plain_text(const smart_ptr<engine>& engine_ptr,const forward_iterator& text_start,const forward_iterator& text_end,content_type say_as,const voice_profile& profile,std::forward_iterator_tag)
     {
-      std::auto_ptr<document> doc_ptr(new document(engine_ptr,profile));
+      std::unique_ptr<document> doc_ptr(new document(engine_ptr,profile));
       typedef utf::text_iterator<forward_iterator> text_iterator;
       tts_markup m;
       m.say_as=say_as;
@@ -604,9 +604,9 @@ namespace RHVoice
   }
 
   template<typename input_iterator>
-  std::auto_ptr<document> document::create_from_ssml(const smart_ptr<engine>& engine_ptr,const input_iterator& text_start,const input_iterator& text_end,const voice_profile& profile)
+  std::unique_ptr<document> document::create_from_ssml(const smart_ptr<engine>& engine_ptr,const input_iterator& text_start,const input_iterator& text_end,const voice_profile& profile)
   {
-    std::auto_ptr<document> doc_ptr(new document(engine_ptr,profile));
+    std::unique_ptr<document> doc_ptr(new document(engine_ptr,profile));
     #ifdef _MSC_VER
     typedef std::iterator_traits<input_iterator>::value_type char_type;
     #else

--- a/src/include/core/dtree.hpp
+++ b/src/include/core/dtree.hpp
@@ -225,11 +225,11 @@ namespace RHVoice
 
     private:
       std::string feature_name;
-      std::auto_ptr<condition> question;
-      std::auto_ptr<node> yes_node,no_node;
+      std::unique_ptr<condition> question;
+      std::unique_ptr<node> yes_node,no_node;
     };
 
-    std::auto_ptr<node> root;
+    std::unique_ptr<node> root;
 
     dtree(const dtree&);
     dtree& operator=(const dtree&);
@@ -252,13 +252,13 @@ namespace RHVoice
 
     const value& predict(const item& i) const
     {
-      std::auto_ptr<item_features> f(new item_features(i));
+      std::unique_ptr<item_features> f(new item_features(i));
       return predict(*f);
     }
 
     const value& predict(const std::map<std::string,value>& m) const
     {
-      std::auto_ptr<explicit_features> f(new explicit_features(m));
+      std::unique_ptr<explicit_features> f(new explicit_features(m));
       return predict(*f);
     }
   };

--- a/src/include/core/emoji.hpp
+++ b/src/include/core/emoji.hpp
@@ -68,9 +68,9 @@ emoji_property_extended_pictographic=32
       return false;
 }
 
-    virtual std::auto_ptr<emoji_scanner_state> next(emoji_char_t c) const
+    virtual std::unique_ptr<emoji_scanner_state> next(emoji_char_t c) const
     {
-      return std::auto_ptr<emoji_scanner_state>();
+      return std::unique_ptr<emoji_scanner_state>();
 }
 
   private:
@@ -97,7 +97,7 @@ emoji_property_extended_pictographic=32
     bool process(utf8::uint32_t c);
 
   private:
-    std::auto_ptr<emoji_scanner_state> state;
+    std::unique_ptr<emoji_scanner_state> state;
     std::size_t result;
     std::size_t length;
   };

--- a/src/include/core/ini_parser.hpp
+++ b/src/include/core/ini_parser.hpp
@@ -53,7 +53,7 @@ namespace RHVoice
     ini_parser& operator=(const ini_parser&);
     std::string unescape(const std::string& s) const;
 
-    std::auto_ptr<std::ifstream> instream;
+    std::unique_ptr<std::ifstream> instream;
     bool standard_format;
     std::string section,key,value;
   };

--- a/src/include/core/language.hpp
+++ b/src/include/core/language.hpp
@@ -280,11 +280,11 @@ namespace RHVoice
     const fst syl_fst;
     std::vector<std::string> msg_cap_letter,msg_char_code;
     std::map<utf8::uint32_t,std::string> whitespace_symbols;
-    std::auto_ptr<fst> english_phone_mapping_fst;
-    std::auto_ptr<fst> emoji_fst;
-std::auto_ptr<fst> qst_fst;
-    std::auto_ptr<dtree> pitch_mod_dtree;
-    std::auto_ptr<dtree> dur_mod_dtree;
+    std::unique_ptr<fst> english_phone_mapping_fst;
+    std::unique_ptr<fst> emoji_fst;
+std::unique_ptr<fst> qst_fst;
+    std::unique_ptr<dtree> pitch_mod_dtree;
+    std::unique_ptr<dtree> dur_mod_dtree;
     pitch::targets_spec_parser pts_parser;
     userdict::dict udict;
 

--- a/src/include/core/mage_hts_engine_impl.hpp
+++ b/src/include/core/mage_hts_engine_impl.hpp
@@ -88,8 +88,8 @@ namespace RHVoice
     void do_generate_samples(frame_t& f);
     void do_generate_samples();
 
-    std::auto_ptr<MAGE::Mage> mage;
-    std::auto_ptr<_HTS_Vocoder> vocoder;
+    std::unique_ptr<MAGE::Mage> mage;
+    std::unique_ptr<_HTS_Vocoder> vocoder;
     int frame_shift;
     double alpha;
     int mgc_order;

--- a/src/include/core/rules.hpp
+++ b/src/include/core/rules.hpp
@@ -217,7 +217,7 @@ namespace RHVoice
           throw file_format_error(err_msg);
         if(key_length!=0)
           {
-            std::auto_ptr<record> data(new record(key_length));
+            std::unique_ptr<record> data(new record(key_length));
             if(!reader(f,data->value))
               throw file_format_error(err_msg);
             st.data=data.release();

--- a/src/include/core/russian.hpp
+++ b/src/include/core/russian.hpp
@@ -96,7 +96,7 @@ namespace RHVoice
     const fst dict_fst;
     const fst stress_fst;
     const rules<uint8_t> stress_rules;
-    std::auto_ptr<fst> rulex_dict_fst,rulex_rules_fst;
+    std::unique_ptr<fst> rulex_dict_fst,rulex_rules_fst;
   };
 }
 #endif

--- a/src/include/core/std_hts_engine_impl.hpp
+++ b/src/include/core/std_hts_engine_impl.hpp
@@ -45,7 +45,7 @@ namespace RHVoice
     void set_speed();
     void edit_pitch();
 
-    std::auto_ptr<_HTS_Engine> engine;
+    std::unique_ptr<_HTS_Engine> engine;
   };
 }
 #endif

--- a/src/include/core/trie.hpp
+++ b/src/include/core/trie.hpp
@@ -130,7 +130,7 @@ namespace RHVoice
       template<typename forward_iterator>
       pointer add_child(forward_iterator first,forward_iterator last)
       {
-        std::auto_ptr<node> child(new node(first,last));
+        std::unique_ptr<node> child(new node(first,last));
         children.push_back(child.get());
         return child.release();
       }
@@ -138,7 +138,7 @@ namespace RHVoice
       void split(label_iterator pos)
       {
         label_type new_label(label_iterator(label.begin()),pos);
-        std::auto_ptr<node> child(new node(pos,label_iterator(label.end())));
+        std::unique_ptr<node> child(new node(pos,label_iterator(label.end())));
         child->children.reserve(1);
         child->value=value;
         value=0;
@@ -178,7 +178,7 @@ namespace RHVoice
     template<typename forward_iterator>
     value_type& insert(forward_iterator first,forward_iterator last)
     {
-      std::auto_ptr<value_type> val(new value_type());
+      std::unique_ptr<value_type> val(new value_type());
       node* child=get_node(first,last);
       if(child->value==0)
         child->value=val.release();
@@ -188,7 +188,7 @@ namespace RHVoice
     template<typename forward_iterator>
     value_type& insert(forward_iterator first,forward_iterator last,const value_type& value)
     {
-      std::auto_ptr<value_type> val(new value_type(value));
+      std::unique_ptr<value_type> val(new value_type(value));
       node* child=get_node(first,last);
       delete child->value;
       child->value=val.release();

--- a/src/include/core/userdict.hpp
+++ b/src/include/core/userdict.hpp
@@ -726,7 +726,7 @@ namespace RHVoice
       template<class T>
       static inline ruleset* create()
       {
-        std::auto_ptr<ruleset> rs(new ruleset);
+        std::unique_ptr<ruleset> rs(new ruleset);
         rs->append<T>();
         return rs.release();
       }
@@ -734,7 +734,7 @@ namespace RHVoice
       template<class T,typename A>
       static inline ruleset* create(const A& a)
       {
-        std::auto_ptr<ruleset> rs(new ruleset);
+        std::unique_ptr<ruleset> rs(new ruleset);
         rs->append<T,A>(a);
         return rs.release();
       }
@@ -753,7 +753,7 @@ namespace RHVoice
 
     struct parse_state
     {
-      std::auto_ptr<ruleset> result;
+      std::unique_ptr<ruleset> result;
       bool error;
 
       parse_state():

--- a/src/lib/lib.cpp
+++ b/src/lib/lib.cpp
@@ -90,7 +90,7 @@ private:
   RHVoice_message_struct(const RHVoice_message_struct&);
   RHVoice_message_struct& operator=(const RHVoice_message_struct&);
 
-  std::auto_ptr<document> doc_ptr;
+  std::unique_ptr<document> doc_ptr;
   RHVoice_callbacks callbacks;
   void* user_data;
 };

--- a/src/sd_module/speech_synthesizer.cpp
+++ b/src/sd_module/speech_synthesizer.cpp
@@ -94,7 +94,7 @@ namespace RHVoice
     {
       try
         {
-          std::auto_ptr<document> doc;
+          std::unique_ptr<document> doc;
           switch(msg.type)
             {
             case tts_message_text:

--- a/src/service/service.cpp
+++ b/src/service/service.cpp
@@ -313,7 +313,7 @@ namespace
     Glib::ustring text;
 
   private:
-    virtual std::auto_ptr<RHVoice::document> create_document() const=0;
+    virtual std::unique_ptr<RHVoice::document> create_document() const=0;
     double pitch,rate,volume;
   };
 
@@ -343,7 +343,7 @@ namespace
     }
 
   private:
-    std::auto_ptr<RHVoice::document> create_document() const;
+    std::unique_ptr<RHVoice::document> create_document() const;
   };
 
   session::session(const Glib::RefPtr<Gio::DBus::Connection>& connection_,const Glib::ustring& name_):
@@ -433,7 +433,7 @@ namespace
   {
     try
       {
-        std::auto_ptr<RHVoice::document> doc=create_document();
+        std::unique_ptr<RHVoice::document> doc=create_document();
         if(!parent.is_stopping())
           {
             doc->speech_settings.absolute.rate=rate;
@@ -461,7 +461,7 @@ namespace
       }
   }
 
-  std::auto_ptr<RHVoice::document> text_task::create_document() const
+  std::unique_ptr<RHVoice::document> text_task::create_document() const
   {
     return RHVoice::document::create_from_plain_text(local_engine_ref,text.begin(),text.end(),RHVoice::content_text,speakers);
   }

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -116,7 +116,7 @@ int main(int argc,const char* argv[])
         profile=eng->create_voice_profile(voice_arg.getValue());
       std::istreambuf_iterator<char> text_start(f_in.is_open()?f_in:std::cin);
       std::istreambuf_iterator<char> text_end;
-      std::auto_ptr<document> doc;
+      std::unique_ptr<document> doc;
       if(ssml_switch.getValue())
         doc=document::create_from_ssml(eng,text_start,text_end,profile);
       else

--- a/src/utils/make-hts-labels.cpp
+++ b/src/utils/make-hts-labels.cpp
@@ -148,7 +148,7 @@ int main(int argc,const char* argv[])
         throw std::runtime_error("Cannot open the input file");
       std::istreambuf_iterator<char> text_start(f_in);
       std::istreambuf_iterator<char> text_end;
-      std::auto_ptr<document> doc=document::create_from_ssml(eng,text_start,text_end);
+      std::unique_ptr<document> doc=document::create_from_ssml(eng,text_start,text_end);
       document::iterator sentence_iter=doc->begin();
       if(labpath_arg.isSet())
         {
@@ -157,7 +157,7 @@ int main(int argc,const char* argv[])
             {
               if(sentence_iter==doc->end())
                 throw std::runtime_error("Sentence count mismatch");
-              std::auto_ptr<utterance> utt=sentence_iter->create_utterance(sentence_position_single);
+              std::unique_ptr<utterance> utt=sentence_iter->create_utterance(sentence_position_single);
               load_mono_labels(*utt,path::join(labpath_arg.getValue(),*it));
               output_labels(*utt,path::join(outpath_arg.getValue(),*it));
               ++sentence_iter;
@@ -173,7 +173,7 @@ int main(int argc,const char* argv[])
               s << "_";
               s << index;
               s << ".lab";
-              std::auto_ptr<utterance> utt=sentence_iter->create_utterance(sentence_position_single);
+              std::unique_ptr<utterance> utt=sentence_iter->create_utterance(sentence_position_single);
               output_labels(*utt,path::join(outpath_arg.getValue(),s.str()));
               ++index;
             }

--- a/src/utils/transcribe-sentences.cpp
+++ b/src/utils/transcribe-sentences.cpp
@@ -40,13 +40,13 @@ int main(int argc,const char* argv[])
         throw std::runtime_error("Cannot open the input file");
       std::istreambuf_iterator<char> text_start(f_in);
       std::istreambuf_iterator<char> text_end;
-      std::auto_ptr<document> doc=document::create_from_ssml(eng,text_start,text_end);
+      std::unique_ptr<document> doc=document::create_from_ssml(eng,text_start,text_end);
       std::ofstream f_out(outpath_arg.getValue().c_str());
       if(!f_out.is_open())
         throw std::runtime_error("Cannot open the output file");
       for(document::iterator it(doc->begin());it!=doc->end();++it)
         {
-          std::auto_ptr<utterance> utt=it->create_utterance(sentence_position_single);
+          std::unique_ptr<utterance> utt=it->create_utterance(sentence_position_single);
           const relation& seg_rel=utt->get_relation("Segment");
           for(relation::const_iterator seg_iter(seg_rel.begin());seg_iter!=seg_rel.end();++seg_iter)
             {


### PR DESCRIPTION
std::auto_ptr is a very old construct with known issues. This patch gets rid of it.