### PR TITLE
Exiting from loop instead of return

### DIFF
--- a/src/core/mage_hts_engine_impl.cpp
+++ b/src/core/mage_hts_engine_impl.cpp
@@ -108,7 +108,7 @@ namespace RHVoice
         pos+=len;
         generate_samples(*label_iter);
         if(output->is_stopped())
-          return;
+          break;
       }
     pitch_editor.finish();
     do_generate_samples();


### PR DESCRIPTION
Appears to be a typo: break should be used to exit from the loop only, in order to allow the proper function wrap-up