### PR TITLE
Adding support for reading DATA_PATH and CONFIG_PATH from environment

### DIFF
--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -17,6 +17,8 @@
 #include "core/config.hpp"
 #include "core/engine.hpp"
 
+#include <cstdlib>
+
 namespace
 {
   const std::string tag("engine");
@@ -29,6 +31,10 @@ namespace RHVoice
     config_path(CONFIG_PATH),
     logger(new event_logger)
   {
+    char* data_path_env = getenv("RHVOICE_DATA_PATH");
+    if (data_path_env) data_path = data_path_env;
+    char* config_path_env = getenv("RHVOICE_CONFIG_PATH");
+    if (config_path_env) config_path = config_path_env;
   }
 
   std::vector<std::string> engine::init_params::get_resource_paths(const std::string& type) const


### PR DESCRIPTION
Useful for debugging/customization: given ENV variables, use them to locate data and config paths.