### PR TITLE
Fixing interruptions of PortAudio-based voice synthesis due to false-failures

### DIFF
--- a/src/audio/portaudio.cpp
+++ b/src/audio/portaudio.cpp
@@ -139,7 +139,7 @@ namespace RHVoice
               throw playback_error();
           }
         res=Pa_WriteStream(stream,samples,count);
-        if(res!=paNoError)
+        if((res!=paNoError)&&(res!=paOutputUnderflowed))
           throw playback_error();
       }
 

--- a/src/include/audio.hpp
+++ b/src/include/audio.hpp
@@ -201,6 +201,11 @@ namespace RHVoice
           params.client_name=client_name;
       }
 
+      unsigned int get_buffer_size() const
+      {
+        return params.buffer_size;
+      }
+
       void set_buffer_size(unsigned int buffer_size)
       {
         if(is_initialized())

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -37,6 +37,7 @@ namespace
     bool play_speech(const short* samples,std::size_t count);
     void finish();
     bool set_sample_rate(int sample_rate);
+    bool set_buffer_size(unsigned int buffer_size);
 
   private:
     audio::playback_stream stream;
@@ -58,6 +59,21 @@ namespace
         if(stream.is_open()&&(stream.get_sample_rate()!=sample_rate))
           stream.close();
         stream.set_sample_rate(sample_rate);
+        return true;
+      }
+    catch(...)
+      {
+        return false;
+      }
+  }
+
+  bool audio_player::set_buffer_size(unsigned int buffer_size)
+  {
+    try
+      {
+        if(stream.is_open()&&(stream.get_buffer_size()!=buffer_size))
+          stream.close();
+        stream.set_buffer_size(buffer_size);
         return true;
       }
     catch(...)
@@ -110,6 +126,7 @@ int main(int argc,const char* argv[])
             throw std::runtime_error("Cannot open the input file");
         }
       audio_player player(outpath_arg.getValue());
+      player.set_buffer_size(20);
       smart_ptr<engine> eng(new engine);
       voice_profile profile;
       if(!voice_arg.getValue().empty())


### PR DESCRIPTION
Unbreaking false-failures in PortAudio backend:
* Allowing paOutputUnderflowed return status from Pa_WriteStream(), which is actually not an error. This is a highly important fix, which resolves random interruptions of synthesis in the middle of the phrase with the RHVoice-test.
* Adding a proper non-zero value for Pa_OpenStream() framesPerBuffer argument, and its propagation by RHVoice-test as a buffer_size parameter.
