### PR TITLE
Fix broken link to LICENSE.md in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ is provided by RHVoice itself).
 ## License
 
 The main library is distributed under [LGPL v2.1](https://www.gnu.org/licenses/lgpl-2.1.html) or later.
-some components and voices use other licenses.for more information please read [license.md](license.md) file.
+some components and voices use other licenses.for more information please read [LICENSE.md](LICENSE.md) file.


### PR DESCRIPTION
“License” word was written in lowercase whilst the real file name in uppercase (except its extension).