### PR TITLE
Allowed to use CLI11 instead of tclap for CLI.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ endif()
 
 
 set("dev" OFF CACHE BOOL "The build will only be used for development: no global installation, run from the source directory, compile helper utilities")
+set("WITH_CLI11" OFF CACHE BOOL "Use CLI11 instead of bundled tclap")
 set("ENABLE_MAGE" ON CACHE BOOL "Build with MAGE")
 set("WITH_DATA" ON CACHE BOOL "Build packages with data. Long to compress. When debugging RHVoice itself it makes sense to disable it.")
 #set("spd_version" validate_spd_version CACHE ??? "Speech dispatcher version")

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -19,6 +19,10 @@ target_link_libraries("RHVoice-test" "RHVoice" "RHVoice_audio")
 target_include_directories("RHVoice-test" PRIVATE "${TCLAP_INCLUDE_DIR}" "${HTS_LABELS_KIT_INCLUDES}")
 harden("RHVoice-test")
 
+if(WITH_CLI11)
+	target_compile_definitions(RHVoice-test PRIVATE WITH_CLI11)
+endif(WITH_CLI11)
+
 install(TARGETS "RHVoice-test"
 	RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
 	COMPONENT "test"

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -25,6 +25,10 @@ target_include_directories("RHVoice-make-hts-labels" PRIVATE "${TCLAP_INCLUDE_DI
 target_link_libraries("RHVoice-make-hts-labels" "RHVoice_core" "libhts_engine")
 harden("RHVoice-make-hts-labels")
 
+if(WITH_CLI11)
+	target_compile_definitions(RHVoice-make-hts-labels PRIVATE WITH_CLI11)
+endif(WITH_CLI11)
+
 install(TARGETS "RHVoice-transcribe-sentences" "RHVoice-make-hts-labels"
 	RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
 	COMPONENT "utils"


### PR DESCRIPTION
When debugging memory safety issues I found that both MSan and valgrind point to tclap. I have tried CLI11 (with zero success, now they point to CLI11). Anyway, being able to switch between different libs is useful because any of them can acquire a grave bug and we should be sure that the bug is not in the lib but in our code.