### PR TITLE
Reverting the default sample rate setting from 48k back to 24k

### DIFF
--- a/src/include/core/sample_rate.hpp
+++ b/src/include/core/sample_rate.hpp
@@ -35,7 +35,7 @@ namespace RHVoice
   {
   public:
     sample_rate_property():
-      enum_property<sample_rate_t>("sample_rate",sample_rate_48k)
+      enum_property<sample_rate_t>("sample_rate",sample_rate_24k)
     {
       define("16k",sample_rate_16k);
       define("22k",sample_rate_22k);


### PR DESCRIPTION
that has been leaked from the experimenting into the PR.

The bug has been introduced in https://github.com/Olga-Yakovleva/RHVoice/pull/135/files#diff-77cffe8341bf99e3beb9f65df6f5eb8bR45 and hasn't affected speech_dispatcher and RHVoice-test, that's why gone undetected into `master`.

Fixes: #180