### PR TITLE
Added an empty line between different kinds of includes in the SAPI5 module

### DIFF
--- a/src/sapi/IEnumSpObjectTokensImpl.cpp
+++ b/src/sapi/IEnumSpObjectTokensImpl.cpp
@@ -16,6 +16,7 @@
 #include <stdexcept>
 #include <new>
 #include <algorithm>
+
 #include "IEnumSpObjectTokensImpl.hpp"
 #include "core/voice.hpp"
 #include "core/language.hpp"

--- a/src/sapi/IEnumSpObjectTokensImpl.hpp
+++ b/src/sapi/IEnumSpObjectTokensImpl.hpp
@@ -23,6 +23,7 @@
 #include <sperror.h>
 #include <comdef.h>
 #include <comip.h>
+
 #include "tts_base.hpp"
 #include "com.hpp"
 #include "voice_attributes.hpp"

--- a/src/sapi/ISpDataKeyImpl.hpp
+++ b/src/sapi/ISpDataKeyImpl.hpp
@@ -23,6 +23,7 @@
 #include <sapi.h>
 #include <sapiddk.h>
 #include <sperror.h>
+
 #include "core/utf.hpp"
 #include "core/str.hpp"
 #include "com.hpp"

--- a/src/sapi/SpeakImpl.hpp
+++ b/src/sapi/SpeakImpl.hpp
@@ -20,6 +20,7 @@
 #include <windows.h>
 #include <sapi.h>
 #include <sapiddk.h>
+
 #include "core/client.hpp"
 #include "core/voice_profile.hpp"
 #include "core/document.hpp"

--- a/src/sapi/dbg_out.hpp
+++ b/src/sapi/dbg_out.hpp
@@ -17,6 +17,7 @@
 #define RHVOICE_SAPI_DBG_HPP
 
 #include <windows.h>
+
 #include "utils.hpp"
 
 namespace RHVoice

--- a/src/sapi/registry.hpp
+++ b/src/sapi/registry.hpp
@@ -18,6 +18,7 @@
 
 #include <windows.h>
 #include <string>
+
 #include "core/exception.hpp"
 
 namespace RHVoice

--- a/src/sapi/text_iterator.hpp
+++ b/src/sapi/text_iterator.hpp
@@ -19,6 +19,7 @@
 #include <iterator>
 #include <sapi.h>
 #include <sapiddk.h>
+
 #include "core/utf.hpp"
 
 namespace RHVoice

--- a/src/sapi/tts_base.cpp
+++ b/src/sapi/tts_base.cpp
@@ -14,6 +14,7 @@
 /* along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
 #include <shlobj.h>
+
 #include "core/path.hpp"
 #include "registry.hpp"
 #include "utils.hpp"

--- a/src/sapi/utils.hpp
+++ b/src/sapi/utils.hpp
@@ -19,6 +19,7 @@
 #include <cstring>
 #include <iterator>
 #include <string>
+
 #include "utf8.h"
 
 namespace RHVoice

--- a/src/sapi/voice_attributes.hpp
+++ b/src/sapi/voice_attributes.hpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <sstream>
 #include <locale>
+
 #include "core/voice_profile.hpp"
 #include "utils.hpp"
 

--- a/src/sapi/voice_token.hpp
+++ b/src/sapi/voice_token.hpp
@@ -18,6 +18,7 @@
 
 #include <comdef.h>
 #include <comip.h>
+
 #include "voice_attributes.hpp"
 #include "ISpDataKeyImpl.hpp"
 


### PR DESCRIPTION
This makes it a bit easier to read.