### PR TITLE
Fix Arina's voice lang definition in cmake

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -43,6 +43,7 @@ set("VOICE_Leticia-F123_LICENSE" "by-sa-4.0") # Brazilian Portuguese
 
 set("VOICE_aleksandr_LANG" "ru")
 set("VOICE_anna_LANG" "ru")
+set("VOICE_arina_LANG" "ru")
 set("VOICE_elena_LANG" "ru")
 set("VOICE_irina_LANG" "ru")
 set("VOICE_artemiy_LANG" "ru")


### PR DESCRIPTION
There was a new voice released with #234, but it wasn't added to correspondig cmake file, so now it leads to build failure.
This PR fixes it. 