### PR TITLE
cmake hardening fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.9)
 project("RHVoice")
 
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_SOURCE_DIR}/cmake" "${CMAKE_SOURCE_DIR}/cmake/thirdparty/sanitizers/cmake")
@@ -29,11 +29,7 @@ getVersionFromGit("RHVOICE" "1.2.2")
 if(${CMAKE_VERSION} VERSION_GREATER "3.12") 
 	set(CMAKE_CXX_STANDARD 20)
 else()
-	if(${CMAKE_VERSION} VERSION_GREATER "3.8") 
-		set(CMAKE_CXX_STANDARD 17)
-	else()
-		set(CMAKE_CXX_STANDARD 14)
-	endif()
+	set(CMAKE_CXX_STANDARD 17)
 endif()
 
 


### PR DESCRIPTION
[This commit](https://github.com/Olga-Yakovleva/RHVoice/commit/90aeda8ed27bc26560256aeb1d30912380de3f74) introduced "IPO" checks. But looks like author forgot that CMake requires policy rule for `CMP0069` to be set if `check_ipo_supported()` function is used (see [Cmake documentation on that policy and related links](https://cmake.org/cmake/help/v3.18/policy/CMP0069.html)).

Without this fix in `cmake/Hardening` - compilation fails.
Without this fix in other places - CMake throws a billion of warnings about that (and disables hardening on all the subprojects)

This PR fixes all of that.