### PR TITLE
make doc path configureable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ set("languages_dir" "${data_dir}/languages")
 set("voices_dir" "${data_dir}/voices")
 
 set("config_dir" "${CMAKE_INSTALL_FULL_SYSCONFDIR}/RHVoice")
-set("common_doc_dir" "${CMAKE_INSTALL_FULL_DATAROOTDIR}/doc")
+set("common_doc_dir" "${CMAKE_INSTALL_FULL_DATAROOTDIR}/doc" CACHE PATH "Documentation directory path")
 
 set(SubpackagesDir "${CMAKE_CURRENT_SOURCE_DIR}/src")
 set("licenses_dir" "${CMAKE_CURRENT_SOURCE_DIR}/licenses")


### PR DESCRIPTION
this PR make documentation dir (currently it is used as base path for voices license files) configureable.
it will help some distros to configure buildsystem to install package files to proper paths.

For example, on gentoo, package **MUST** install it's doc files to `/usr/share/doc/PkgName-PkgVersion[-revision]`, and currently RHVoice installs (without patching) licenses to `/usr/share/doc/$voicename/copyright`.

It is anyway will be better to keep voices docs ad licenses under at least `/usr/share/doc/RHVoice`, and not under "raw" `/usr/share/doc/`, but at least making it configureable untie hands for many distro maintainers.