### PR TITLE
more configurability

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,9 @@
+set(BUILD_CLIENT ON CACHE BOOL "Build standalone RHVoice-client application")
+set(BUILD_UTILS ON CACHE BOOL "Build some useful utils")
+set(BUILD_TESTS ON CACHE BOOL "Build test applications")
+set(BUILD_SERVICE ON CACHE BOOL "Build RHVoice server application")
+set(BUILD_SPEECHDISPATCHER_MODULE ON CACHE BOOL "Build SpeechDispatcher module")
+
 set(INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
 configure_file("${INCLUDE_DIR}/core/config.h.in" "${INCLUDE_DIR}/core/config.h")
 
@@ -7,17 +13,31 @@ set(HTS_LABELS_KIT_INCLUDES "${UTF8_INCLUDE_DIR}" "${RAPIDXML_INCLUDE_DIR}")
 add_subdirectory("core")
 add_subdirectory("audio")
 add_subdirectory("lib")
-add_subdirectory("bin")
-add_subdirectory("utils")
-add_subdirectory("test")
+
+if (BUILD_CLIENT)
+	add_subdirectory("bin")
+endif(BUILD_CLIENT)
+
+if (BUILD_UTILS)
+	add_subdirectory("utils")
+endif(BUILD_UTILS)
+
+if (BUILD_TESTS)
+	add_subdirectory("test")
+endif(BUILD_TESTS)
 
 IF (WIN32)
 	#add_subdirectory("sapi")
 	#add_subdirectory("nvda-synthDriver")
 	#add_subdirectory("wininst")
 else()
-	add_subdirectory("service")
-	add_subdirectory("sd_module")
+	if(BUILD_SERVICE)
+		add_subdirectory("service")
+	endif(BUILD_SERVICE)
+
+	if(BUILD_SPEECHDISPATCHER_MODULE)
+		add_subdirectory("sd_module")
+	endif(BUILD_SPEECHDISPATCHER_MODULE)
 endif()
 
 pass_through_cpack_vars()


### PR DESCRIPTION
It makes it possible to disable some parts of package, which can be useful in various cases:

Say, user1 wants to install "service-only" on "server" (or PC), and "client-only" on a laptop (or smartphone), and don't need sd module.

Or, maybe user2 only needs sd-module, but doesn't want neither utils, service, nor client.
And even tests.
